### PR TITLE
Fix moved mamajek_alt.dat in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md
 include LICENCE.txt
 include scopesim_templates/defaults.yaml
-include scopesim_templates/utils/mamajek_alt.dat
+include scopesim_templates/stellar/mamajek_alt.dat
 prune scopesim_templates/tests*
 prune *OLD_*


### PR DESCRIPTION
#21 moves `mamajek_alt.dat` but doesn't update `MANIFEST.in`, hence `mamajek_alt.dat` is not copied when pip installing ScopeSim Templates.

This PR fixes that.