### PR TITLE
Fix TypeError: None is not a valid Unit when simulating cluster.

### DIFF
--- a/scopesim_templates/stellar/clusters.py
+++ b/scopesim_templates/stellar/clusters.py
@@ -99,7 +99,8 @@ def cluster(mass=1E3, distance=50000, core_radius=1, **kwargs):
 
     # 8. make table with (x,y,ref,weight)
     tbl = Table(names=["x", "y", "ref", "weight", "masses", "spec_types"],
-                data= [ x,   y,   ref,   weight,   masses,   spec_types ])
+                data= [ x,   y,   ref,   weight,   masses,   spec_types ],
+                units=[u.arcsec, u.arcsec, None, None, u.solMass, None])
 
     # 9. make Source with table, spectra
     src = rc.Source(table=tbl, spectra=spectra)


### PR DESCRIPTION
Simulating a cluster requires the cluster to be shifted before it can be simulated.

Closes #24.

Closes https://github.com/AstarVienna/ScopeSim/issues/112.

Required to pass all IRDB tests: https://github.com/AstarVienna/irdb/pull/47