### PR TITLE
Cleanup imports

### DIFF
--- a/scopesim_templates/calibration/calibration.py
+++ b/scopesim_templates/calibration/calibration.py
@@ -8,7 +8,7 @@ from astropy import units as u
 
 from spextra import Spextrum
 
-from ...rc import Source, __config__
+from ..rc import Source, __config__
 from ..utils.general_utils import add_function_call_str
 from ..misc.misc import uniform_source
 

--- a/scopesim_templates/calibration/calibration.py
+++ b/scopesim_templates/calibration/calibration.py
@@ -8,7 +8,7 @@ from astropy import units as u
 
 from spextra import Spextrum
 
-from scopesim_templates.rc import Source, __config__
+from ...rc import Source, __config__
 from ..utils.general_utils import add_function_call_str
 from ..misc.misc import uniform_source
 

--- a/scopesim_templates/micado/cluster.py
+++ b/scopesim_templates/micado/cluster.py
@@ -1,10 +1,10 @@
 """A standard cluster for MICADO."""
-from scopesim_templates.utils.general_utils import function_call_str, add_function_call_str
 
-import scopesim_templates.stellar.clusters
+from ..utils.general_utils import add_function_call_str
+from ..stellar import clusters
 
 
 @add_function_call_str
 def cluster():
     """A basic cluster."""
-    return scopesim_templates.stellar.clusters.cluster(mass=10000, distance=2000, core_radius=.1)
+    return clusters.cluster(mass=10000, distance=2000, core_radius=.1)

--- a/scopesim_templates/micado/darkness.py
+++ b/scopesim_templates/micado/darkness.py
@@ -1,4 +1,4 @@
 """Empty sky template, used for dark measurements."""
-from scopesim_templates.calibration import empty_sky as darkness
+from ..calibration import empty_sky as darkness
 
 __all__ = [darkness]

--- a/scopesim_templates/micado/flatlamp.py
+++ b/scopesim_templates/micado/flatlamp.py
@@ -1,10 +1,10 @@
 """Flat lamp for MICADO."""
-import numpy
+
 import numpy as np
 from astropy.io import fits
 import astropy.units as u
-from scopesim import Source
-import scopesim
+
+from ..rc import Source
 
 
 def flatlamp(
@@ -76,8 +76,8 @@ def flatlamp(
 
     sa = 1.0200000e+02
     se = 3.3502039e+05
-    lam = numpy.logspace(numpy.log(sa), numpy.log(se), base=numpy.e,
-                         num=number_of_points) * u.Angstrom
+    lam = np.logspace(np.log(sa), np.log(se), base=np.e,
+                      num=number_of_points) * u.Angstrom
 
     return Source(
             image_hdu=hdu,

--- a/scopesim_templates/micado/pinhole_masks.py
+++ b/scopesim_templates/micado/pinhole_masks.py
@@ -1,7 +1,8 @@
 import numpy as np
 from astropy import units as u
-from scopesim import Source
 from synphot import BlackBody1D, SourceSpectrum, Empirical1D
+
+from ..rc import Source
 
 
 def pinhole_mask(x, y, waves, temperature=1500*u.K, sum_factor=1):

--- a/scopesim_templates/micado/spectral_calibrations.py
+++ b/scopesim_templates/micado/spectral_calibrations.py
@@ -8,8 +8,7 @@ from astropy import units as u
 from synphot import SourceSpectrum, Empirical1D
 from synphot.units import PHOTLAM
 
-from scopesim import Source
-from scopesim.optics import image_plane_utils as ipu
+from ..rc import Source, im_plane_utils
 
 DATA_DIR = Path(__file__).parent / "data"
 
@@ -84,7 +83,8 @@ def line_list(unit_flux=1*PHOTLAM,
     dh = 0.5 * height / 3600         # input needed in [deg]
     pixel_scale = 0.1 * dw
 
-    hdr = ipu.header_from_list_of_xy([-dw, dw], [-dh, dh], pixel_scale)  # [deg]
+    hdr = im_plane_utils.header_from_list_of_xy([-dw, dw], [-dh, dh],
+                                                pixel_scale)  # [deg]
     hdr["SPEC_REF"] = 0
     im = np.ones((hdr["NAXIS1"], hdr["NAXIS2"]))
     field = fits.ImageHDU(header=hdr, data=im)

--- a/scopesim_templates/misc/misc.py
+++ b/scopesim_templates/misc/misc.py
@@ -13,7 +13,7 @@ from astropy.utils.decorators import deprecated_renamed_argument
 from synphot import SourceSpectrum, Empirical1D
 
 from spextra import Spextrum
-from ..rc import Source, ter_curve_utils as tu #  , scopesim_utils as su
+from ..rc import Source, ter_curve_utils as tu
 from ..utils.general_utils import add_function_call_str, make_img_wcs_header,\
     RA0, DEC0
 

--- a/scopesim_templates/rc.py
+++ b/scopesim_templates/rc.py
@@ -13,6 +13,7 @@ SystemDict = scopesim.system_dict.SystemDict
 ter_curve_utils = scopesim.effects.ter_curves_utils
 im_plane_utils = scopesim.optics.image_plane_utils
 scopesim_utils = scopesim.utils
+load_example_optical_train = scopesim.load_example_optical_train
 
 PKG_DIR = Path(__file__).parent
 with (PKG_DIR / "defaults.yaml").open(encoding="utf-8") as file:

--- a/scopesim_templates/stellar/clusters.py
+++ b/scopesim_templates/stellar/clusters.py
@@ -6,9 +6,9 @@ from astropy.utils import deprecated_renamed_argument
 
 from spextra import Spextrum
 
-from scopesim_templates import rc
-from scopesim_templates.stellar import imf, cluster_utils as cu
-from scopesim_templates.utils.general_utils import function_call_str, RA0, DEC0
+from ..rc import __config__, Source
+from ..utils.general_utils import function_call_str, RA0, DEC0
+from . import imf, cluster_utils as cu
 
 
 __all__ = ["cluster"]
@@ -68,7 +68,7 @@ def cluster(mass=1E3, distance=50000, core_radius=1, ra=RA0, dec=DEC0,
               "core_radius": core_radius,
               "tidal_radius": None,
               "multiplicity_object": None,
-              "seed": rc.__config__["!random.seed"],
+              "seed": __config__["!random.seed"],
               "ra": ra,
               "dec": dec}
     params.update(kwargs)
@@ -124,7 +124,7 @@ def cluster(mass=1E3, distance=50000, core_radius=1, ra=RA0, dec=DEC0,
                 units=[u.arcsec, u.arcsec, None, None, u.solMass, None])
 
     # 9. make Source with table, spectra
-    src = rc.Source(table=tbl, spectra=spectra)
+    src = Source(table=tbl, spectra=spectra)
     src.meta.update(params)
 
     return src

--- a/scopesim_templates/stellar/clusters.py
+++ b/scopesim_templates/stellar/clusters.py
@@ -1,3 +1,5 @@
+"""Currently only contains a simple zero-age open cluster."""
+
 import numpy as np
 import pyckles
 from astropy import units as u

--- a/scopesim_templates/stellar/stars.py
+++ b/scopesim_templates/stellar/stars.py
@@ -6,10 +6,10 @@ from astropy.utils.decorators import deprecated_renamed_argument
 import pyckles
 from spextra import Spextrum
 
-from scopesim_templates.stellar import stars_utils as su
-from scopesim_templates.utils.general_utils import function_call_str, \
-    RA0, DEC0, add_function_call_str
-from scopesim_templates import rc
+from ..rc import __config__, Source
+from ..utils.general_utils import RA0, DEC0, add_function_call_str,\
+    function_call_str
+from . import stars_utils as su
 
 
 __all__ = ["star",
@@ -61,7 +61,7 @@ def star_field(n, mmin, mmax, width, height=None, filter_name="V",
               "width": width,
               "height": height,
               "filter_name": "V",
-              "seed": rc.__config__["!random.seed"],
+              "seed": __config__["!random.seed"],
               "ra": ra,
               "dec": dec}
     params.update(kwargs)
@@ -255,7 +255,7 @@ def stars(filter_name, amplitudes, spec_types, x, y, library="pyckles",
     tbl = Table(names=["x", "y", "ref", "weight", "spec_types"],
                 data=[x, y, ref, weight, spec_types])
 
-    src = rc.Source(spectra=spectra, table=tbl)
+    src = Source(spectra=spectra, table=tbl)
     return src
 
 

--- a/scopesim_templates/tests/test_calibration/test_calibration.py
+++ b/scopesim_templates/tests/test_calibration/test_calibration.py
@@ -1,7 +1,8 @@
-from scopesim_templates import calibration
 from astropy.table import Table
-from scopesim import Source
 from synphot import SourceSpectrum
+
+from scopesim_templates import calibration
+from scopesim_templates.rc import Source
 
 
 class TestEmptySky:

--- a/scopesim_templates/tests/test_micado/test_cluster.py
+++ b/scopesim_templates/tests/test_micado/test_cluster.py
@@ -1,9 +1,10 @@
 """Test cluster."""
+
 from astropy.table import Table
 from synphot import SourceSpectrum
+
 from scopesim_templates.micado import cluster
 from scopesim_templates.rc import Source
-import scopesim_templates
 
 
 class TestCluster:

--- a/scopesim_templates/tests/test_micado/test_darkness.py
+++ b/scopesim_templates/tests/test_micado/test_darkness.py
@@ -1,6 +1,8 @@
 """Test for darkness."""
+
 from astropy.table import Table
 from synphot import SourceSpectrum
+
 from scopesim_templates.micado import darkness
 from scopesim_templates.rc import Source
 

--- a/scopesim_templates/tests/test_micado/test_flatlamp.py
+++ b/scopesim_templates/tests/test_micado/test_flatlamp.py
@@ -1,4 +1,5 @@
 """Test for flatlamp."""
+
 from astropy.io.fits import ImageHDU
 from synphot import SourceSpectrum
 

--- a/scopesim_templates/tests/test_micado/test_pinhole_mask.py
+++ b/scopesim_templates/tests/test_micado/test_pinhole_mask.py
@@ -1,14 +1,13 @@
 """Test for flatlamp."""
+
 import numpy as np
 from astropy.table import Table
 from astropy import units as u
 from matplotlib import pyplot as plt
 from synphot import SourceSpectrum
 
-from scopesim import load_example_optical_train
-
 from scopesim_templates.micado.pinhole_masks import pinhole_mask
-from scopesim_templates.rc import Source
+from scopesim_templates.rc import Source, load_example_optical_train
 
 PLOTS = False
 

--- a/scopesim_templates/tests/test_micado/test_spectral_calibrations.py
+++ b/scopesim_templates/tests/test_micado/test_spectral_calibrations.py
@@ -1,6 +1,5 @@
 # This test suite takes long because it creates a 10 million entry spectrum 5x over
 
-import pytest
 from pytest import approx
 
 import numpy as np

--- a/scopesim_templates/tests/test_micado/test_viking_fields.py
+++ b/scopesim_templates/tests/test_micado/test_viking_fields.py
@@ -1,14 +1,12 @@
 import pytest
 
 import numpy as np
-from astropy.io import fits
 from astropy import units as u
 from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 
-from scopesim import load_example_optical_train
-
 from scopesim_templates.micado import viking_fields as vf
+from scopesim_templates.rc import load_example_optical_train
 
 PLOTS = False
 

--- a/scopesim_templates/tests/test_stellar/test_cluster_utils.py
+++ b/scopesim_templates/tests/test_stellar/test_cluster_utils.py
@@ -2,9 +2,11 @@ from pytest import approx, mark
 from collections.abc import Iterable
 import numpy as np
 from astropy.table import Table
+
 import scopesim_templates.stellar.cluster_utils as cu
 
 from matplotlib import pyplot as plt
+
 PLOTS = False
 
 

--- a/scopesim_templates/tests/test_stellar/test_star_utils.py
+++ b/scopesim_templates/tests/test_stellar/test_star_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 import pyckles
+
 from scopesim_templates.stellar import stars_utils as stu
 
 

--- a/scopesim_templates/tests/test_stellar/test_stars.py
+++ b/scopesim_templates/tests/test_stellar/test_stars.py
@@ -4,15 +4,16 @@ import numpy as np
 import astropy.units as u
 import synphot as sp
 
-from scopesim_templates.stellar import *
-from scopesim_templates.rc import ter_curve_utils as tcu
-from scopesim_templates.rc import Source
+from scopesim_templates.stellar import star, stars, star_field, star_grid,\
+    cluster
+from scopesim_templates.rc import Source, ter_curve_utils as tcu
 
 
 def source_eq(source_lhs: Source, source_rhs: Source):
     """hacky way to ensure two source"""
     eq = len(source_lhs.spectra) == len(source_rhs.spectra)
-    for spectrum_lhs, spectrum_rhs in zip(source_lhs.spectra, source_rhs.spectra):
+    for spectrum_lhs, spectrum_rhs in zip(source_lhs.spectra,
+                                          source_rhs.spectra):
         eq = eq and all(spectrum_lhs.waveset == spectrum_rhs.waveset)
     return eq
 
@@ -25,10 +26,10 @@ class TestStar:
         src_from_star_unit = star("Generic/Johnson.V", 0*u.mag, "A0V", 0, 0)
         src_from_stars_unit = stars("Generic/Johnson.V", [0*u.mag], ["A0V"], [0], [0])
 
-        a = source_eq(src_from_star, src_from_stars)
-        assert(source_eq(src_from_star, src_from_stars))
-        assert(source_eq(src_from_star, src_from_star_unit))
-        assert(source_eq(src_from_star, src_from_stars_unit))
+        _ = source_eq(src_from_star, src_from_stars)
+        assert source_eq(src_from_star, src_from_stars)
+        assert source_eq(src_from_star, src_from_star_unit)
+        assert source_eq(src_from_star, src_from_stars_unit)
 
 
 class TestStars:

--- a/scopesim_templates/tests/test_utils/test_cleared_cache.py
+++ b/scopesim_templates/tests/test_utils/test_cleared_cache.py
@@ -1,5 +1,5 @@
 from scopesim_templates import cluster
-from scopesim import Source
+from scopesim_templates.rc import Source
 
 
 def test_actually_works():


### PR DESCRIPTION
- Only import `ScopeSim` in one place. This was mostly already done, but not consistently. Should also make the changeover to ScopeSIm_Core easier.
- All internal imports relative, use `from ... import ...` more.
- Remove unused or double imports.
- Finally add a docstring along the way.