### PR TITLE
Disable warning on input of scopesim_templates

### DIFF
--- a/scopesim_templates/__init__.py
+++ b/scopesim_templates/__init__.py
@@ -6,6 +6,10 @@ from . import misc
 from . import stellar
 from . import utils
 
+# This warning is emitted when just doing "import scopesim_templates", which
+# should be a normal non-warning thing to do.
+# TODO: Find a way to emit this warning only when the functions below are
+#       accessed directly.
 warnings.warn("In a future version top level function calls will be removed. "
               "Always use this syntax: from module.submodule import function",
               DeprecationWarning, stacklevel=2)

--- a/scopesim_templates/__init__.py
+++ b/scopesim_templates/__init__.py
@@ -10,9 +10,9 @@ from . import utils
 # should be a normal non-warning thing to do.
 # TODO: Find a way to emit this warning only when the functions below are
 #       accessed directly.
-warnings.warn("In a future version top level function calls will be removed. "
-              "Always use this syntax: from module.submodule import function",
-              DeprecationWarning, stacklevel=2)
+# warnings.warn("In a future version top level function calls will be removed. "
+#               "Always use this syntax: from module.submodule import function",
+#               DeprecationWarning, stacklevel=2)
 from .misc.misc import source_from_image, source_from_file, source_from_cube
 from .stellar.stars import star, stars, star_grid, star_field
 from .stellar.clusters import cluster


### PR DESCRIPTION
Simply importing ScopeSim_Templates would emit a warning:

```
>>> import scopesim_templates
<stdin>:1: DeprecationWarning: In a future version top level function calls will be removed. Always use this syntax: from module.submodule import function
```

Importing the package should be normal, warning-free. This PR therefore disables the warning.

We should find a better way to emit this warning. As it is now, it just annoys and desensitizes the users.
 