### PR TITLE
Comment out print statements, perhaps replace with logging later

### DIFF
--- a/scopesim_templates/extragalactic/galaxies.py
+++ b/scopesim_templates/extragalactic/galaxies.py
@@ -273,7 +273,7 @@ def spiral_two_component(extent=60*u.arcsec, fluxes=(0, 0), offset=(0, 0)):
     filename = "spiral_two_component.fits"
     url = __config__["!file.server_url"]
     use_cache = __config__["!file.use_cache"]
-    print(url+filename)
+    # print(url+filename)
 
     path = download_file(remote_url=url+filename, cache=use_cache)
     hdulist = fits.open(path)

--- a/scopesim_templates/stellar/imf.py
+++ b/scopesim_templates/stellar/imf.py
@@ -205,7 +205,7 @@ class IMF():
                     isMultiple = np.append(isMultiple, newIsMultiple)
                     systemMasses = np.append(systemMasses, newSystemMasses)
                     t2 = time.time()
-                    print(F"All loop: {t2 - t1}")
+                    # print(F"All loop: {t2 - t1}")
             else:
                 newTotalMassTally = newMasses.sum()
 

--- a/scopesim_templates/stellar/stars.py
+++ b/scopesim_templates/stellar/stars.py
@@ -223,7 +223,7 @@ def stars(filter_name, amplitudes, spec_types, x, y, library="pyckles",
         pickles_lib = pyckles.SpectralLibrary("pickles",
                                               return_style="synphot")
         cat_spec_types = su.nearest_spec_type(unique_types, pickles_lib.table)
-        print(cat_spec_types)
+        # print(cat_spec_types)
     # scale the spectra and get the weights
     if amplitudes.unit in [u.mag, u.ABmag, u.STmag]:
         zero = 0 * amplitudes.unit


### PR DESCRIPTION
Remove some print statements, so the ScopeSim output becomes more clean.

Perhaps we can replace some of the print statements with INFO or DEBUG logs later. Therefore they are only commented out, not removed.