### PR TITLE
Add calibration sources required by METIS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
     "scopesim>=0.7.0",
     "pyckles>=0.2",
-    "spextra>=0.33",
+    "spextra>=0.40.0",
     "astar-utils>=0.2.1",
 ]
 

--- a/scopesim_templates/metis/__init__.py
+++ b/scopesim_templates/metis/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from laser import laser_spectrum
+from pinhole_mask import pinhole_mask

--- a/scopesim_templates/metis/__init__.py
+++ b/scopesim_templates/metis/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
-from laser import laser_spectrum
-from pinhole_mask import pinhole_mask
+from .laser import laser_spectrum_lm, laser_spectrum_n
+from .pinhole_mask import pinhole_mask

--- a/scopesim_templates/metis/__init__.py
+++ b/scopesim_templates/metis/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from laser import laser_spectrum

--- a/scopesim_templates/metis/laser.py
+++ b/scopesim_templates/metis/laser.py
@@ -11,10 +11,12 @@ from ..rc import Source, im_plane_utils
 
 
 def laser_spectrum(img_size=(12, 12),
-                   waves=np.arange(3, 6, .001)*u.um,
                    centers=[3.39, 4.73, 5.263]*u.um,
                    fwhms=[8E-8, 8E-7, 6E-5]*u.um,
                    fluxes=[1, 7, 500],
+                   waves=None,
+                   specdict=None,
+):
     """
     Create laser calibration spectrum source for METIS.
 
@@ -22,8 +24,6 @@ def laser_spectrum(img_size=(12, 12),
     ----------
     img_size : TYPE, optional
         FOV size in arcsec, plus a little extra. The default is (12, 12).
-    waves : TYPE, optional
-        Input wavelength axis. The default is np.arange(3, 6, .001)*u.um.
     centers : TYPE, optional
         Emission line centers. The default is [3.39, 4.73, 5.263]*u.um.
     fwhms : TYPE, optional
@@ -31,12 +31,26 @@ def laser_spectrum(img_size=(12, 12),
     fluxes : TYPE, optional
         Emission line total fluxes. The default is [1, 7, 500] to create lines
         of roughly equal amplitude.
+    waves : array-like, optional
+        Input wavelength axis. Either `waves` or `specdict` must be given. If
+        both are given, `waves` takes precedence.The default is None.
+    specdict : Mapping, optional
+        Dict-like structure containing the keys "wave_min", "wave_max" and
+        "spectral_bin_width", which is used to construct the wavelength axis.
+        Either `waves` or `specdict` must be given. If both are given, `waves`
+        takes precedence. The default is None.
 
     Returns
     -------
     src : Source
 
     """
+    if waves is None:
+        if specdict is None:
+            raise ValueError("Either waves or specdict must be given.")
+        waves = np.arange(specdict["wave_min"], specdict["wave_max"],
+                          specdict["spectral_bin_width"])
+
     # Taken from micado.spectral_calibration.line_list:
     dw = 0.5 * img_size[0] / 3600         # input needed in [deg]
     dh = 0.5 * img_size[1] / 3600         # input needed in [deg]

--- a/scopesim_templates/metis/laser.py
+++ b/scopesim_templates/metis/laser.py
@@ -64,12 +64,13 @@ def laser_spectrum(
     hdr["SPEC_REF"] = 0
     im = np.ones((hdr["NAXIS1"], hdr["NAXIS2"]))
     field = fits.ImageHDU(header=hdr, data=im)
-    spec = Spextrum.emission_line_spectrum(centers, fwhms, fluxes, waves=waves)
+    spec = Spextrum.emission_line_spectrum(centers.round(5), fwhms, fluxes,
+                                           waves=waves)
     src = Source(image_hdu=field, spectra=spec)
     return src
 
 
-def laser_spectrum_lm(specdict, n_tunable: int = 5, **kwargs):
+def laser_spectrum_lm(specdict, n_tunable: int = 20, **kwargs):
     """
     Calibration laser for METIS LM bands.
 
@@ -85,7 +86,7 @@ def laser_spectrum_lm(specdict, n_tunable: int = 5, **kwargs):
     n_tunable : int, optional
         Number of emission lines created for the tunable laser between 4.68 and
         4.78 um. Passing 1 will create a single line at 4.73 um.
-        The default is 5.
+        The default is 20.
     **kwargs : TYPE
         Any other keyword arguments passed to ``laser_spectrum``.
         In particular, `centers`, `fwhms` and `fluxes` will override the

--- a/scopesim_templates/metis/laser.py
+++ b/scopesim_templates/metis/laser.py
@@ -14,7 +14,7 @@ def laser_spectrum(img_size=(12, 12),
                    waves=np.arange(3, 6, .001)*u.um,
                    centers=[3.39, 4.73, 5.263]*u.um,
                    fwhms=[8E-8, 8E-7, 6E-5]*u.um,
-                   fluxes=[20, 1, 22]):
+                   fluxes=[1, 7, 500],
     """
     Create laser calibration spectrum source for METIS.
 
@@ -29,7 +29,7 @@ def laser_spectrum(img_size=(12, 12),
     fwhms : TYPE, optional
         Emission line FWHMs. The default is [8E-8, 8E-7, 6E-5]*u.um.
     fluxes : TYPE, optional
-        Emission line total fluxes. The default is [20, 1, 22] to create lines
+        Emission line total fluxes. The default is [1, 7, 500] to create lines
         of roughly equal amplitude.
 
     Returns

--- a/scopesim_templates/metis/laser.py
+++ b/scopesim_templates/metis/laser.py
@@ -2,4 +2,4 @@
 """WCU laser spectrum for METIS."""
 
 def laser_spectrum():
-    pass
+    ...

--- a/scopesim_templates/metis/laser.py
+++ b/scopesim_templates/metis/laser.py
@@ -35,10 +35,10 @@ def laser_spectrum(img_size=(12, 12),
         Input wavelength axis. Either `waves` or `specdict` must be given. If
         both are given, `waves` takes precedence.The default is None.
     specdict : Mapping, optional
-        Dict-like structure containing the keys "wave_min", "wave_max" and
-        "spectral_bin_width", which is used to construct the wavelength axis.
-        Either `waves` or `specdict` must be given. If both are given, `waves`
-        takes precedence. The default is None.
+        Dict-like structure containing the keys "wave_min", "wave_max",
+        "spectral_bin_width" and "wave_unit", which is used to construct the
+        wavelength axis. Either `waves` or `specdict` must be given. If both
+        are given, `waves` takes precedence. The default is None.
 
     Returns
     -------
@@ -48,8 +48,11 @@ def laser_spectrum(img_size=(12, 12),
     if waves is None:
         if specdict is None:
             raise ValueError("Either waves or specdict must be given.")
-        waves = np.arange(specdict["wave_min"], specdict["wave_max"],
-                          specdict["spectral_bin_width"])
+        waves = np.arange(
+            specdict["wave_min"],
+            specdict["wave_max"],
+            specdict["spectral_bin_width"]
+        ) * u.Unit(specdict["wave_unit"])
 
     # Taken from micado.spectral_calibration.line_list:
     dw = 0.5 * img_size[0] / 3600         # input needed in [deg]

--- a/scopesim_templates/metis/laser.py
+++ b/scopesim_templates/metis/laser.py
@@ -7,9 +7,11 @@ from astropy.io import fits
 
 from spextra import Spextrum
 
+from ..utils.general_utils import add_function_call_str
 from ..rc import Source, im_plane_utils
 
 
+@add_function_call_str
 def laser_spectrum(
         centers,
         fwhms,

--- a/scopesim_templates/metis/laser.py
+++ b/scopesim_templates/metis/laser.py
@@ -1,5 +1,52 @@
 # -*- coding: utf-8 -*-
 """WCU laser spectrum for METIS."""
 
-def laser_spectrum():
-    ...
+import numpy as np
+from astropy import units as u
+from astropy.io import fits
+
+from spextra import Spextrum
+
+from ..rc import Source, im_plane_utils
+
+
+def laser_spectrum(img_size=(12, 12),
+                   waves=np.arange(3, 6, .001)*u.um,
+                   centers=[3.39, 4.73, 5.263]*u.um,
+                   fwhms=[8E-8, 8E-7, 6E-5]*u.um,
+                   fluxes=[20, 1, 22]):
+    """
+    Create laser calibration spectrum source for METIS.
+
+    Parameters
+    ----------
+    img_size : TYPE, optional
+        FOV size in arcsec, plus a little extra. The default is (12, 12).
+    waves : TYPE, optional
+        Input wavelength axis. The default is np.arange(3, 6, .001)*u.um.
+    centers : TYPE, optional
+        Emission line centers. The default is [3.39, 4.73, 5.263]*u.um.
+    fwhms : TYPE, optional
+        Emission line FWHMs. The default is [8E-8, 8E-7, 6E-5]*u.um.
+    fluxes : TYPE, optional
+        Emission line total fluxes. The default is [20, 1, 22] to create lines
+        of roughly equal amplitude.
+
+    Returns
+    -------
+    src : Source
+
+    """
+    # Taken from micado.spectral_calibration.line_list:
+    dw = 0.5 * img_size[0] / 3600         # input needed in [deg]
+    dh = 0.5 * img_size[1] / 3600         # input needed in [deg]
+    pixel_scale = 0.1 * dw
+
+    hdr = im_plane_utils.header_from_list_of_xy(
+        [-dw, dw], [-dh, dh], pixel_scale)  # [deg]
+    hdr["SPEC_REF"] = 0
+    im = np.ones((hdr["NAXIS1"], hdr["NAXIS2"]))
+    field = fits.ImageHDU(header=hdr, data=im)
+    spec = Spextrum.emission_line_spectrum(centers, fwhms, fluxes, waves=waves)
+    src = Source(image_hdu=field, spectra=spec)
+    return src

--- a/scopesim_templates/metis/laser.py
+++ b/scopesim_templates/metis/laser.py
@@ -10,27 +10,27 @@ from spextra import Spextrum
 from ..rc import Source, im_plane_utils
 
 
-def laser_spectrum(img_size=(12, 12),
-                   centers=[3.39, 4.73, 5.263]*u.um,
-                   fwhms=[8E-8, 8E-7, 6E-5]*u.um,
-                   fluxes=[1, 7, 500],
-                   waves=None,
-                   specdict=None,
+def laser_spectrum(
+        centers,
+        fwhms,
+        fluxes,
+        img_size=(12, 12),
+        waves=None,
+        specdict=None,
 ):
     """
     Create laser calibration spectrum source for METIS.
 
     Parameters
     ----------
+    centers : TYPE
+        Emission line centers.
+    fwhms : TYPE
+        Emission line FWHMs.
+    fluxes : TYPE
+        Emission line total fluxes.
     img_size : TYPE, optional
         FOV size in arcsec, plus a little extra. The default is (12, 12).
-    centers : TYPE, optional
-        Emission line centers. The default is [3.39, 4.73, 5.263]*u.um.
-    fwhms : TYPE, optional
-        Emission line FWHMs. The default is [8E-8, 8E-7, 6E-5]*u.um.
-    fluxes : TYPE, optional
-        Emission line total fluxes. The default is [1, 7, 500] to create lines
-        of roughly equal amplitude.
     waves : array-like, optional
         Input wavelength axis. Either `waves` or `specdict` must be given. If
         both are given, `waves` takes precedence.The default is None.
@@ -67,3 +67,85 @@ def laser_spectrum(img_size=(12, 12),
     spec = Spextrum.emission_line_spectrum(centers, fwhms, fluxes, waves=waves)
     src = Source(image_hdu=field, spectra=spec)
     return src
+
+
+def laser_spectrum_lm(specdict, n_tunable: int = 5, **kwargs):
+    """
+    Calibration laser for METIS LM bands.
+
+    Create a fixed red and blue laser as well as a variable number of tunable
+    laser lines in between.
+
+    Parameters
+    ----------
+    specdict : dict-like
+        Dict-like structure containing the keys "wave_min", "wave_max",
+        "spectral_bin_width" and "wave_unit", which is used to construct the
+        wavelength axis. Usually this means ``cmd["!SIM.spectral"]``.
+    n_tunable : int, optional
+        Number of emission lines created for the tunable laser between 4.68 and
+        4.78 um. Passing 1 will create a single line at 4.73 um.
+        The default is 5.
+    **kwargs : TYPE
+        Any other keyword arguments passed to ``laser_spectrum``.
+        In particular, `centers`, `fwhms` and `fluxes` will override the
+        default values and any lines created by `n_tunable`. If those are
+        overridding, make sure the shapes of those three arguments match.
+
+    Returns
+    -------
+    src : Source
+
+    Notes
+    -----
+    The default values for the emission lines are 3.39 and 5.263 um for the
+    fixed lasers, with FWHM of 8E-8 and 6E-5 um respectively. The various lines
+    created by the tunable laser all use the same FWHM of 8E-7 um. The fluxes
+    of all lines are scaled to create lines of roughly equal height.
+
+    """
+    if n_tunable == 1:
+        tunable_cen = [4.73] * u.um
+    else:
+        tunable_cen = np.linspace(4.68, 4.78, n_tunable) * u.um
+
+    defaults = {
+        "centers": [3.39, *tunable_cen.value, 5.263] * u.um,
+        "fwhms": [8E-8, *[8E-7]*len(tunable_cen), 6E-5] * u.um,
+        "fluxes": [1, *[7]*len(tunable_cen), 500],
+        "specdict": specdict
+    } | kwargs
+    return laser_spectrum(**defaults)
+
+
+def laser_spectrum_n(specdict, **kwargs):
+    """
+    Calibration laser for METIS N band.
+
+    Create equal emission lines at 9, 10, 11 and 12 um.
+
+    Parameters
+    ----------
+    specdict : dict-like
+        Dict-like structure containing the keys "wave_min", "wave_max",
+        "spectral_bin_width" and "wave_unit", which is used to construct the
+        wavelength axis. Usually this means ``cmd["!SIM.spectral"]``.
+    **kwargs : TYPE
+        Any other keyword arguments passed to ``laser_spectrum``.
+
+    Returns
+    -------
+    src : Source
+
+    Notes
+    -----
+    The default of 1E-8 um is used as a best-guess for the line's FWHMs.
+    The relative fluxes are scaled to produce lines of roughly equal height.
+    """
+    defaults = {
+        "centers": [9, 10, 11, 12] * u.um,
+        "fwhms": 4 * [1E-8] * u.um,
+        "fluxes": [1.3, 1.2, 1.1, 1],
+        "specdict": specdict
+    } | kwargs
+    return laser_spectrum(**defaults)

--- a/scopesim_templates/metis/laser.py
+++ b/scopesim_templates/metis/laser.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+"""WCU laser spectrum for METIS."""
+
+def laser_spectrum():
+    pass

--- a/scopesim_templates/metis/pinhole_mask.py
+++ b/scopesim_templates/metis/pinhole_mask.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""Pinhole mask for METIS."""
+
+from itertools import product
+
+import numpy as np
+from astropy import units as u
+
+from ..micado.pinhole_masks import pinhole_mask as micado_mask
+
+
+def pinhole_mask(
+        nx=5,
+        ny=28,
+        dx=0.45,
+        dy=0.27945,
+        waves=np.arange(3, 6, .001)*u.um,
+        **kwargs
+):
+    """
+    Create pinhole mask source for METIS, simulated as a grid of point sources.
+
+    This currently uses the (flexible)  MICADO pinhole mask internally.
+
+    Parameters
+    ----------
+    nx : int, optional
+        Number of points along x axis. The default is 5.
+    ny : int, optional
+        Number of points along y axis. The default is 28.
+    dx : float, optional
+        (Half) extension in x direction. The default is 0.45.
+    dy : float, optional
+        (Half) extension in y direction. The default is 0.27945.
+    waves : array-like, optional
+        Wavelength axis. The default is np.arange(3, 6, .001)*u.um.
+    **kwargs
+        Any other kwargs passed to micado.pinhole_mask.
+
+    Returns
+    -------
+    TYPE
+        DESCRIPTION.
+
+    """
+    x, y = zip(*product(np.linspace(-dx, dx, nx), np.linspace(-dy, dy, ny)))
+    return micado_mask(x, y, waves, **kwargs)

--- a/scopesim_templates/metis/pinhole_mask.py
+++ b/scopesim_templates/metis/pinhole_mask.py
@@ -6,9 +6,11 @@ from itertools import product
 import numpy as np
 from astropy import units as u
 
+from ..utils.general_utils import add_function_call_str
 from ..micado.pinhole_masks import pinhole_mask as micado_mask
 
 
+@add_function_call_str
 def pinhole_mask(
         nx=5,
         ny=28,


### PR DESCRIPTION
Adds a basic pinhole mask on the basis of the already existing one for MICADO (and using the positions defined in #31), as well as a basic flat-field laser spectrum source.