### PR TITLE
Replace dev_master link with main

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/AstarVienna/ScopeSim_Templates/actions/workflows/tests.yml/badge.svg)](https://github.com/AstarVienna/ScopeSim_Templates/actions/workflows/tests.yml/badge.svg)
 [![Documentation Status](https://readthedocs.org/projects/scopesim-templates/badge/?version=latest)](https://scopesim-templates.readthedocs.io/en/latest)
-[![Codecov](https://img.shields.io/codecov/c/github/AstarVienna/ScopeSim_Templates/\branch/dev_master?logo=codecov)](https://app.codecov.io/gh/AstarVienna/ScopeSim_Templates/tree/dev_master)
+[![Codecov](https://img.shields.io/codecov/c/github/AstarVienna/ScopeSim_Templates/branch/main?logo=codecov)](https://app.codecov.io/gh/AstarVienna/ScopeSim_Templates/tree/main)
 [![PyPI - Version](https://img.shields.io/pypi/v/ScopeSim-Templates)](https://pypi.org/project/ScopeSim-Templates/)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)


### PR DESCRIPTION
Apparently the markdown link checker is not useless:
https://github.com/AstarVienna/ScopeSim_Templates/actions/runs/9057573131/job/24881801092

> 🚫 README.md, [https://img.shields.io/codecov/c/github/AstarVienna/ScopeSim_Templates/\branch/dev_master?logo=codecov](https://img.shields.io/codecov/c/github/AstarVienna/ScopeSim_Templates//branch/dev_master?logo=codecov) , 404, 5, null
> - Checking README.md...
> 
> 💥 Error: Some hyperlinks in the specified files are invalid.