### PR TITLE
Accept both pre-v0.9 and current ScopeSim versions

### DIFF
--- a/scopesim_templates/tests/test_calibration/test_calibration.py
+++ b/scopesim_templates/tests/test_calibration/test_calibration.py
@@ -10,5 +10,6 @@ class TestEmptySky:
         sky = calibration.calibration.empty_sky()
         assert isinstance(sky, Source)
         assert isinstance(sky.spectra[0], SourceSpectrum)
-        assert isinstance(sky.fields[0], Table)
+        assert (isinstance(getattr(sky.fields[0], "field", sky.fields[0]), Table)
+                or isinstance(sky.fields[0], Table))
         assert sky.fields[0]["ref"][0] == 0

--- a/scopesim_templates/tests/test_micado/test_cluster.py
+++ b/scopesim_templates/tests/test_micado/test_cluster.py
@@ -15,4 +15,5 @@ class TestCluster:
         sky = cluster()
         assert isinstance(sky, Source)
         assert isinstance(sky.spectra[0], SourceSpectrum)
-        assert isinstance(sky.fields[0], Table)
+        assert (isinstance(getattr(sky.fields[0], "field", sky.fields[0]), Table)
+                or isinstance(sky.fields[0], Table))

--- a/scopesim_templates/tests/test_micado/test_darkness.py
+++ b/scopesim_templates/tests/test_micado/test_darkness.py
@@ -15,5 +15,6 @@ class TestDarkness:
         sky = darkness()
         assert isinstance(sky, Source)
         assert isinstance(sky.spectra[0], SourceSpectrum)
-        assert isinstance(sky.fields[0], Table)
+        assert (isinstance(getattr(sky.fields[0], "field", sky.fields[0]), Table)
+                or isinstance(sky.fields[0], Table))
         assert sky.fields[0]["ref"][0] == 0

--- a/scopesim_templates/tests/test_micado/test_flatlamp.py
+++ b/scopesim_templates/tests/test_micado/test_flatlamp.py
@@ -15,4 +15,4 @@ class TestFlatlamp:
         lamp = flatlamp()
         assert isinstance(lamp, Source)
         assert isinstance(lamp.spectra[0], SourceSpectrum)
-        assert isinstance(lamp.fields[0], ImageHDU)
+        assert isinstance(getattr(lamp.fields[0], "field", lamp.fields[0]), ImageHDU)

--- a/scopesim_templates/tests/test_micado/test_pinhole_mask.py
+++ b/scopesim_templates/tests/test_micado/test_pinhole_mask.py
@@ -24,7 +24,9 @@ class TestPinholeMask:
 
         assert isinstance(ph_mask, Source)
         assert isinstance(ph_mask.spectra[0], SourceSpectrum)
-        assert isinstance(ph_mask.fields[0], Table)
+        assert (isinstance(getattr(ph_mask.fields[0], "field",
+                                   ph_mask.fields[0]), Table)
+                or isinstance(ph_mask.fields[0], Table))
 
     def test_pinhole_with_basic_instrument(self):
         dr = np.arange(-25, 26, 5)      # [arcsec]

--- a/scopesim_templates/tests/test_micado/test_spectral_calibrations.py
+++ b/scopesim_templates/tests/test_micado/test_spectral_calibrations.py
@@ -25,7 +25,7 @@ class TestLineList:
             plt.show()
 
         assert isinstance(src.spectra[0], SourceSpectrum)
-        assert isinstance(src.fields[0], fits.ImageHDU)
+        assert isinstance(getattr(src.fields[0], "field", src.fields[0]), fits.ImageHDU)
 
     def test_returns_flux_scaled_spectrum(self):
         src1 = mic_sc.line_list()

--- a/scopesim_templates/tests/test_stellar/test_clusters.py
+++ b/scopesim_templates/tests/test_stellar/test_clusters.py
@@ -24,22 +24,36 @@ class TestCluster:
 
     @pytest.mark.usefixtures("basic_cluster")
     def test_spectra_are_correct_type(self, basic_cluster):
-        assert all(isinstance(spec, Spextrum)
-                   for spec in basic_cluster.spectra)
+        if (hasattr(basic_cluster.fields[0], "field") and
+                not isinstance(basic_cluster.fields[0], Table)):
+            assert all(isinstance(spec, Spextrum)
+                       for spec in basic_cluster.spectra.values())
+        else:
+            assert all(isinstance(spec, Spextrum)
+                       for spec in basic_cluster.spectra)
 
     @pytest.mark.usefixtures("basic_cluster")
     def test_spectra_waverange(self, basic_cluster):
         # TODO: don't know if it makes sense to test like this
-        wvrng_min = [s.waverange.min().to(u.um).value
-                     for s in basic_cluster.spectra]
-        wvrng_max = [s.waverange.max().to(u.um).value
-                     for s in basic_cluster.spectra]
+        if (hasattr(basic_cluster.fields[0], "field") and
+                not isinstance(basic_cluster.fields[0], Table)):
+            wvrng_min = [s.waverange.min().to(u.um).value
+                         for s in basic_cluster.spectra.values()]
+            wvrng_max = [s.waverange.max().to(u.um).value
+                         for s in basic_cluster.spectra.values()]
+        else:
+            wvrng_min = [s.waverange.min().to(u.um).value
+                         for s in basic_cluster.spectra]
+            wvrng_max = [s.waverange.max().to(u.um).value
+                         for s in basic_cluster.spectra]
         assert all(wave == approx(0.115) for wave in wvrng_min)
         assert all(wave == approx(2.5) for wave in wvrng_max)
 
     @pytest.mark.usefixtures("basic_cluster")
     def test_field_is_correct_type(self, basic_cluster):
-        assert isinstance(basic_cluster.fields[0], Table)
+        assert (isinstance(getattr(basic_cluster.fields[0], "field",
+                                   basic_cluster.fields[0]), Table)
+                or isinstance(basic_cluster.fields[0], Table))
         assert len(basic_cluster.fields[0]) > 0
 
     @pytest.mark.usefixtures("basic_cluster")

--- a/scopesim_templates/tests/test_stellar/test_stars.py
+++ b/scopesim_templates/tests/test_stellar/test_stars.py
@@ -11,9 +11,14 @@ from scopesim_templates.rc import Source, ter_curve_utils as tcu
 def source_eq(source_lhs: Source, source_rhs: Source):
     """hacky way to ensure two source"""
     eq = len(source_lhs.spectra) == len(source_rhs.spectra)
-    for spectrum_lhs, spectrum_rhs in zip(source_lhs.spectra,
-                                          source_rhs.spectra):
-        eq = eq and all(spectrum_lhs.waveset == spectrum_rhs.waveset)
+    if isinstance(source_lhs.spectra, list):
+        for spectrum_lhs, spectrum_rhs in zip(source_lhs.spectra,
+                                              source_rhs.spectra):
+            eq = eq and all(spectrum_lhs.waveset == spectrum_rhs.waveset)
+    elif isinstance(source_lhs.spectra, dict):
+        for spectrum_lhs, spectrum_rhs in zip(source_lhs.spectra.values(),
+                                              source_rhs.spectra.values()):
+            eq = eq and all(spectrum_lhs.waveset == spectrum_rhs.waveset)
     return eq
 
 

--- a/scopesim_templates/tests/test_utils/test_validate_content.py
+++ b/scopesim_templates/tests/test_utils/test_validate_content.py
@@ -27,58 +27,70 @@ SOURCE_LIST = [star(filter_name="Ks", amplitude=10*u.mag),
 # Run all tests on each source indivdually
 @pytest.mark.parametrize("src", SOURCE_LIST)
 class TestContentOfFields:
-    """
-    Test the <Source>.fields attribute to check that the content is correct
-    """
+    """Test the <Source>.fields attribute to check that the content is correct."""
+
     def test_is_fields_a_list(self, src):
         assert isinstance(src.fields, list)
 
     def test_fields_list_has_only_imagehdus_or_tables(self, src):
         for field in src.fields:
-            assert isinstance(field, (Table, ImageHDU))
+            if not isinstance(field, Table):
+                assert isinstance(getattr(field, "field", field), (Table, ImageHDU))
 
     def test_any_tables_have_correct_column_names(self, src):
         for field in src.fields:
             if isinstance(field, Table):
-                req_colnames = ["x", "y", "ref", "weight"]
-                assert all([col in field.colnames for col in req_colnames])
+                fld = field
+            else:
+                if isinstance(getattr(field, "field", field), Table):
+                    fld = getattr(field, "field", field)
+                else:
+                    continue
+
+            req_colnames = ["x", "y", "ref", "weight"]
+            assert all(col in fld.colnames for col in req_colnames)
 
     def test_any_imagehdus_have_correct_header_keywords(self, src):
         for field in src.fields:
-            if isinstance(field, ImageHDU):
+            if isinstance(getattr(field, "field", field), ImageHDU):
                 req_keys = ["SPEC_REF", "NAXIS", "NAXIS1", "NAXIS2",
-                            "CUNIT1", "CUNIT2", "CTYPE1", "CTYPE2", "CDELT1",
-                            "CDELT2", "CRVAL1", "CRVAL2", "CRPIX1", "CRPIX2",
-                            ]
-                assert all([key in field.header for key in req_keys])
+                            "CUNIT1", "CUNIT2", "CTYPE1", "CTYPE2",
+                            "CDELT1", "CDELT2", "CRVAL1", "CRVAL2",
+                            "CRPIX1", "CRPIX2"]
+                assert all(key in field.header for key in req_keys)
 
 
 @pytest.mark.parametrize("src", SOURCE_LIST)
 class TestContentOfSpectra:
-    """
-    Test the <Source>.spectra attribute to check that all spectra are useful
-    """
-    def test_is_spectra_a_list(self, src):
-        assert isinstance(src.spectra, list)
+    """Test the <Source>.spectra attribute to check that all spectra are useful."""
+
+    def test_is_spectra_a_list_or_dict(self, src):
+        # ScopeSim pre-0.9 is a list, afterwards dict. Allow both here.
+        assert isinstance(src.spectra, (list, dict))
 
     def test_spectra_list_has_only_synphot_sourcespectrum_objects(self, src):
-        for spectrum in src.spectra:
-            assert isinstance(spectrum, SourceSpectrum)
+        if isinstance(src.spectra, list):
+            for spectrum in src.spectra:
+                assert isinstance(spectrum, SourceSpectrum)
+        elif isinstance(src.spectra, dict):
+            for spectrum in src.spectra.values():
+                assert isinstance(spectrum, SourceSpectrum)
+        else:
+            raise TypeError(src.spectra)
 
 
 @pytest.mark.parametrize("src", SOURCE_LIST)
 class TestConnectionBetweenFieldsAndSpectra:
-    """
-    Test that all spectra referenced by .fields are in .spectra
-    """
+    """Test that all spectra referenced by .fields are in .spectra."""
+
     def test_all_spectra_in_table_ref_column_exist(self, src):
         for field in src.fields:
-            if isinstance(field, Table):
+            if isinstance(getattr(field, "field", field), Table):
                 for ref in field["ref"]:
                     assert isinstance(src.spectra[ref], SourceSpectrum)
 
     def test_all_spectra_refereced_in_imagehdu_header_exist(self, src):
         for field in src.fields:
-            if isinstance(field, ImageHDU):
+            if isinstance(getattr(field, "field", field), ImageHDU):
                 ref = field.header["SPEC_REF"]
                 assert isinstance(src.spectra[ref], SourceSpectrum)


### PR DESCRIPTION
Bit of a hack, but ensures (hopefully) that tests pass and things work both before and after AstarVienna/ScopeSim#405.

In the neat future we should update the requirements in ScopeSim_Templates and make a v0.5.3 release that uses ScopeSim v0.8.4 and a v0.6.0 release that requires ScopeSim v0.9.x or something along those lines...