### PR TITLE
Remove patchy getattrs now that ScopeSim v0.9.0 is here

### DIFF
--- a/scopesim_templates/tests/test_calibration/test_calibration.py
+++ b/scopesim_templates/tests/test_calibration/test_calibration.py
@@ -13,8 +13,7 @@ class TestEmptySky:
         sky = calibration.calibration.empty_sky()
         assert isinstance(sky, Source)
         assert isinstance(sky.spectra[0], SourceSpectrum)
-        assert (isinstance(getattr(sky.fields[0], "field", sky.fields[0]), Table)
-                or isinstance(sky.fields[0], Table))
+        assert isinstance(sky.fields[0].field, Table)
         assert sky.fields[0]["ref"][0] == 0
 
 
@@ -23,8 +22,7 @@ class TestFlatField:
         flatfield = calibration.calibration.flat_field()
         assert isinstance(flatfield, Source)
         assert isinstance(flatfield.spectra[0], SourceSpectrum)
-        assert (isinstance(getattr(flatfield.fields[0], "field", flatfield.fields[0]), ImageHDU)
-                or isinstance(flatfield.fields[0], ImageHDU))
+        assert isinstance(flatfield.fields[0].field, ImageHDU)
 
 
 class TestLamp:
@@ -40,5 +38,4 @@ class TestLamp:
         )
         assert isinstance(lamp, Source)
         assert isinstance(lamp.spectra[0], SourceSpectrum)
-        assert (isinstance(getattr(lamp.fields[0], "field", lamp.fields[0]), ImageHDU)
-                or isinstance(lamp.fields[0], ImageHDU))
+        assert isinstance(lamp.fields[0].field, ImageHDU)

--- a/scopesim_templates/tests/test_micado/test_cluster.py
+++ b/scopesim_templates/tests/test_micado/test_cluster.py
@@ -15,5 +15,4 @@ class TestCluster:
         sky = cluster()
         assert isinstance(sky, Source)
         assert isinstance(sky.spectra[0], SourceSpectrum)
-        assert (isinstance(getattr(sky.fields[0], "field", sky.fields[0]), Table)
-                or isinstance(sky.fields[0], Table))
+        assert isinstance(sky.fields[0].field, Table)

--- a/scopesim_templates/tests/test_micado/test_darkness.py
+++ b/scopesim_templates/tests/test_micado/test_darkness.py
@@ -15,6 +15,5 @@ class TestDarkness:
         sky = darkness()
         assert isinstance(sky, Source)
         assert isinstance(sky.spectra[0], SourceSpectrum)
-        assert (isinstance(getattr(sky.fields[0], "field", sky.fields[0]), Table)
-                or isinstance(sky.fields[0], Table))
+        assert isinstance(sky.fields[0].field, Table)
         assert sky.fields[0]["ref"][0] == 0

--- a/scopesim_templates/tests/test_micado/test_flatlamp.py
+++ b/scopesim_templates/tests/test_micado/test_flatlamp.py
@@ -15,4 +15,4 @@ class TestFlatlamp:
         lamp = flatlamp()
         assert isinstance(lamp, Source)
         assert isinstance(lamp.spectra[0], SourceSpectrum)
-        assert isinstance(getattr(lamp.fields[0], "field", lamp.fields[0]), ImageHDU)
+        assert isinstance(lamp.fields[0].field, ImageHDU)

--- a/scopesim_templates/tests/test_micado/test_pinhole_mask.py
+++ b/scopesim_templates/tests/test_micado/test_pinhole_mask.py
@@ -24,9 +24,7 @@ class TestPinholeMask:
 
         assert isinstance(ph_mask, Source)
         assert isinstance(ph_mask.spectra[0], SourceSpectrum)
-        assert (isinstance(getattr(ph_mask.fields[0], "field",
-                                   ph_mask.fields[0]), Table)
-                or isinstance(ph_mask.fields[0], Table))
+        assert isinstance(ph_mask.fields[0].field, Table)
 
     def test_pinhole_with_basic_instrument(self):
         dr = np.arange(-25, 26, 5)      # [arcsec]

--- a/scopesim_templates/tests/test_micado/test_spectral_calibrations.py
+++ b/scopesim_templates/tests/test_micado/test_spectral_calibrations.py
@@ -25,7 +25,7 @@ class TestLineList:
             plt.show()
 
         assert isinstance(src.spectra[0], SourceSpectrum)
-        assert isinstance(getattr(src.fields[0], "field", src.fields[0]), fits.ImageHDU)
+        assert isinstance(src.fields[0].field, fits.ImageHDU)
 
     def test_returns_flux_scaled_spectrum(self):
         src1 = mic_sc.line_list()

--- a/scopesim_templates/tests/test_stellar/test_clusters.py
+++ b/scopesim_templates/tests/test_stellar/test_clusters.py
@@ -24,36 +24,22 @@ class TestCluster:
 
     @pytest.mark.usefixtures("basic_cluster")
     def test_spectra_are_correct_type(self, basic_cluster):
-        if (hasattr(basic_cluster.fields[0], "field") and
-                not isinstance(basic_cluster.fields[0], Table)):
-            assert all(isinstance(spec, Spextrum)
-                       for spec in basic_cluster.spectra.values())
-        else:
-            assert all(isinstance(spec, Spextrum)
-                       for spec in basic_cluster.spectra)
+        assert all(isinstance(spec, Spextrum)
+                   for spec in basic_cluster.spectra.values())
 
     @pytest.mark.usefixtures("basic_cluster")
     def test_spectra_waverange(self, basic_cluster):
         # TODO: don't know if it makes sense to test like this
-        if (hasattr(basic_cluster.fields[0], "field") and
-                not isinstance(basic_cluster.fields[0], Table)):
-            wvrng_min = [s.waverange.min().to(u.um).value
-                         for s in basic_cluster.spectra.values()]
-            wvrng_max = [s.waverange.max().to(u.um).value
-                         for s in basic_cluster.spectra.values()]
-        else:
-            wvrng_min = [s.waverange.min().to(u.um).value
-                         for s in basic_cluster.spectra]
-            wvrng_max = [s.waverange.max().to(u.um).value
-                         for s in basic_cluster.spectra]
+        wvrng_min = [s.waverange.min().to(u.um).value
+                     for s in basic_cluster.spectra.values()]
+        wvrng_max = [s.waverange.max().to(u.um).value
+                     for s in basic_cluster.spectra.values()]
         assert all(wave == approx(0.115) for wave in wvrng_min)
         assert all(wave == approx(2.5) for wave in wvrng_max)
 
     @pytest.mark.usefixtures("basic_cluster")
     def test_field_is_correct_type(self, basic_cluster):
-        assert (isinstance(getattr(basic_cluster.fields[0], "field",
-                                   basic_cluster.fields[0]), Table)
-                or isinstance(basic_cluster.fields[0], Table))
+        assert isinstance(basic_cluster.fields[0].field, Table)
         assert len(basic_cluster.fields[0]) > 0
 
     @pytest.mark.usefixtures("basic_cluster")

--- a/scopesim_templates/tests/test_stellar/test_stars.py
+++ b/scopesim_templates/tests/test_stellar/test_stars.py
@@ -11,14 +11,9 @@ from scopesim_templates.rc import Source, ter_curve_utils as tcu
 def source_eq(source_lhs: Source, source_rhs: Source):
     """hacky way to ensure two source"""
     eq = len(source_lhs.spectra) == len(source_rhs.spectra)
-    if isinstance(source_lhs.spectra, list):
-        for spectrum_lhs, spectrum_rhs in zip(source_lhs.spectra,
-                                              source_rhs.spectra):
-            eq = eq and all(spectrum_lhs.waveset == spectrum_rhs.waveset)
-    elif isinstance(source_lhs.spectra, dict):
-        for spectrum_lhs, spectrum_rhs in zip(source_lhs.spectra.values(),
-                                              source_rhs.spectra.values()):
-            eq = eq and all(spectrum_lhs.waveset == spectrum_rhs.waveset)
+    for spectrum_lhs, spectrum_rhs in zip(source_lhs.spectra.values(),
+                                          source_rhs.spectra.values()):
+        eq = eq and all(spectrum_lhs.waveset == spectrum_rhs.waveset)
     return eq
 
 


### PR DESCRIPTION
This was just a temporary workaround anyway, now there's no longer a need for it.