### PR TITLE
Improve API ref on RTD

### DIFF
--- a/docs/_templates/custom-class-template.rst
+++ b/docs/_templates/custom-class-template.rst
@@ -1,0 +1,32 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
+   {% block methods %}
+   .. automethod:: __init__
+
+   {% if methods %}
+   .. rubric:: {{ _('Methods') }}
+
+   .. autosummary::
+   {% for item in methods %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Attributes') }}
+
+   .. autosummary::
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}

--- a/docs/_templates/custom-module-template.rst
+++ b/docs/_templates/custom-module-template.rst
@@ -1,0 +1,66 @@
+{{ fullname | escape | underline}}
+
+.. automodule:: {{ fullname }}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: {{ _('Module Attributes') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in attributes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block functions %}
+   {% if functions %}
+   .. rubric:: {{ _('Functions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in functions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block classes %}
+   {% if classes %}
+   .. rubric:: {{ _('Classes') }}
+
+   .. autosummary::
+      :toctree:
+      :template: custom-class-template.rst
+   {% for item in classes %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block exceptions %}
+   {% if exceptions %}
+   .. rubric:: {{ _('Exceptions') }}
+
+   .. autosummary::
+      :toctree:
+   {% for item in exceptions %}
+      {{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+{% block modules %}
+{% if modules %}
+.. rubric:: Modules
+
+.. autosummary::
+   :toctree:
+   :template: custom-module-template.rst
+   :recursive:
+{% for item in modules %}
+   {{ item }}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,10 +89,6 @@ autodoc_docstring_signature = False
 napoleon_numpy_docstring = True
 napoleon_use_admonition_for_references = True
 
-# apidoc_module_dir = os.path.abspath('../../scopesim_templates/')
-# apidoc_output_dir = 'reference'
-# apidoc_separate_modules = True
-# apidoc_excluded_paths = ["tests/", "docs/"]
 
 # Matplotlib plot directive config parameters
 plot_html_show_source_link = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,9 +15,7 @@
 import os
 import sys
 
-import sphinx_rtd_theme
-
-needs_sphinx = '1.3'
+needs_sphinx = '3.1'
 
 sys.path.insert(0, os.path.abspath('../'))
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.extlinks',
     'sphinx.ext.doctest',
+    'sphinx.ext.napoleon',
     'sphinx_copybutton',
     'myst_nb',
     'numpydoc',
@@ -89,6 +90,8 @@ autosummary_generate = True
 autoclass_content = "class"
 autodoc_default_flags = ["members", "inherited-members"]
 autodoc_docstring_signature = False
+napoleon_numpy_docstring = True
+napoleon_use_admonition_for_references = True
 
 apidoc_module_dir = os.path.abspath('../../scopesim_templates/')
 apidoc_output_dir = 'reference'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,10 +89,10 @@ autodoc_docstring_signature = False
 napoleon_numpy_docstring = True
 napoleon_use_admonition_for_references = True
 
-apidoc_module_dir = os.path.abspath('../../scopesim_templates/')
-apidoc_output_dir = 'reference'
-apidoc_separate_modules = True
-apidoc_excluded_paths = ["tests/", "docs/"]
+# apidoc_module_dir = os.path.abspath('../../scopesim_templates/')
+# apidoc_output_dir = 'reference'
+# apidoc_separate_modules = True
+# apidoc_excluded_paths = ["tests/", "docs/"]
 
 # Matplotlib plot directive config parameters
 plot_html_show_source_link = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,6 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_copybutton',
     'myst_nb',
-    'numpydoc',
     ]
 
 # -- Options for intersphinx extension ---------------------------------------
@@ -85,7 +84,6 @@ extlinks = {'python': ('https://docs.python.org/3/%s', None),
             }
 
 # apidoc settings
-numpydoc_show_class_members = False
 autosummary_generate = True
 autoclass_content = "class"
 autodoc_default_flags = ["members", "inherited-members"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,30 +54,18 @@ in the form of a subpackage**. You can do this either by opening an issue on Git
 
 Documentation for all the helper functions contained in each package can be found in the API documentation for each package.
 
-- `stellar`:
-  : - {func}`star`: Places a single star on the field
-    - {func}`stars`: Places a list of stars on the field
-    - {func}`cluster`:  Creates an age=0 cluster with a user selected mass
-    - {func}`stars_field`: Creates field of stars with random positions
-    - {func}`star_grid`: Creates a field of stars with regular positions
-- `extragalactic`
-  : - {func}`galaxy`: A simple sersic model with a user selected SED from the `speXtra` database
-    - {func}`galaxy3D`:  A more complex model that includes a velocity field and velocity dispersion field
-    - {func}`spiral_two_component`:  Simple two component model with an outer spiral young SED and an old SED bulge
-    - {func}`elliptical`: Another sersic model using the Brown SEDs
-- `misc`
-  : - {func}`point_source`: similar to {func}`star` but using any SED from the `speXtra` database
-    - {func}`uniform_source`: Creates a uniform source with any SED from `speXtra`
-    - {func}`source_from_image_hdu`: creates a source from an `ImageHDU` with an arbitrary flux and scale
-    - {func}`source_from_imagehdu_with_flux`: creates a source from an `ImageHDU` where the flux/pixel is known
-    - {func}`source_from_file`: Load the source from a fits file. Depending on the characteristics other
-      : functions may be more suitable
-    - {func}`source_from_array`: General function to create a source from a 2D `numpy` array
-    - {func}`source_from_cube`:  Wrapper to create a source from a 3D datacube
-- `calibration`:
-  : - {func}`empty_sky`: To simulate a sky without no other sources
-    - {func}`lamp`: Simulates a calibration lamp, i.e. a homogenous source with emissions lines
-    - {func}`flat_field`: Simulates a flat field
+```{eval-rst}
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+   :recursive:
+   :caption: Package Contents
+
+   scopesim_templates.stellar
+   scopesim_templates.extragalactic
+   scopesim_templates.calibration.calibration
+   scopesim_templates.misc.misc
+```
 
 ## Contact
 
@@ -93,19 +81,4 @@ notebooks/starting.md
 notebooks/stellar.md
 notebooks/extragalactic.md
 source_object
-```
-
-## API Reference
-
-```{eval-rst}
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-   :recursive:
-   :caption: Package Contents
-
-   scopesim_templates.stellar
-   scopesim_templates.extragalactic
-   scopesim_templates.calibration.calibration
-   scopesim_templates.misc.misc
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,6 +100,7 @@ source_object
 ```{eval-rst}
 .. autosummary::
    :toctree: _autosummary
+   :template: custom-module-template.rst
    :recursive:
    :caption: Package Contents
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,30 +42,12 @@ pip install scopesim_templates
 
 ScopeSim Templates is a python package, and is therefore by nature infinitely extendable.
 
-As it is impossible for us to know all the details about your specific science case, we provide a
-small selection of basic objects (star cluster, elliptical galaxy, etc).
+As it is impossible for us to know all the details about your specific science case, we provide a small selection of basic objects (star cluster, elliptical galaxy, etc).
+A comprehensive list of those can be found below in the API reference (grouped into subpackages).
 Feel free to start with these to get started with ScopeSim.
 
-However if your needs outgrow the basic objects, we encourage you to extended the objects to fit your
-specific science case. In this case **we strongly encourage you to get in contact with us adding your code
-in the form of a subpackage**. You can do this either by opening an issue on Github, or by emailing one of the developers.
-
-## Available subpackages
-
-Documentation for all the helper functions contained in each package can be found in the API documentation for each package.
-
-```{eval-rst}
-.. autosummary::
-   :toctree: _autosummary
-   :template: custom-module-template.rst
-   :recursive:
-   :caption: Package Contents
-
-   scopesim_templates.stellar
-   scopesim_templates.extragalactic
-   scopesim_templates.calibration.calibration
-   scopesim_templates.misc.misc
-```
+However if your needs outgrow the basic objects, we encourage you to extended the objects to fit your specific science case. In this case **we strongly encourage you to get in contact with us adding your code in the form of a subpackage**.
+You can do this either by opening an issue on Github, or by emailing one of the developers.
 
 ## Contact
 
@@ -81,4 +63,19 @@ notebooks/starting.md
 notebooks/stellar.md
 notebooks/extragalactic.md
 source_object
+```
+
+## API reference
+
+```{eval-rst}
+.. autosummary::
+   :toctree: _autosummary
+   :template: custom-module-template.rst
+   :recursive:
+   :caption: Package Contents
+
+   scopesim_templates.stellar
+   scopesim_templates.extragalactic
+   scopesim_templates.calibration.calibration
+   scopesim_templates.misc.misc
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -2377,17 +2377,6 @@ qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
 testing = ["docopt", "pytest"]
 
 [[package]]
-name = "pbr"
-version = "6.1.0"
-description = "Python Build Reasonableness"
-optional = false
-python-versions = ">=2.6"
-files = [
-    {file = "pbr-6.1.0-py2.py3-none-any.whl", hash = "sha256:a776ae228892d8013649c0aeccbb3d5f99ee15e005a4cbb7e61d55a067b28a2a"},
-    {file = "pbr-6.1.0.tar.gz", hash = "sha256:788183e382e3d1d7707db08978239965e8b9e4e5ed42669bf4758186734d5f24"},
-]
-
-[[package]]
 name = "pexpect"
 version = "4.9.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -3548,21 +3537,6 @@ sphinx = "*"
 dev = ["bump2version", "sphinxcontrib-httpdomain", "transifex-client"]
 
 [[package]]
-name = "sphinxcontrib-apidoc"
-version = "0.4.0"
-description = "A Sphinx extension for running 'sphinx-apidoc' on each build"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "sphinxcontrib-apidoc-0.4.0.tar.gz", hash = "sha256:fe59d15882472aa93c2737afbdea6bedb34ce35cbd34aa4947909f5df1500aad"},
-    {file = "sphinxcontrib_apidoc-0.4.0-py3-none-any.whl", hash = "sha256:18b9fb0cd4816758ec5f8be41c64f8924991dd40fd7b10e666ec9eed2800baff"},
-]
-
-[package.dependencies]
-pbr = "*"
-Sphinx = ">=5.0.0"
-
-[[package]]
 name = "sphinxcontrib-applehelp"
 version = "2.0.0"
 description = "sphinxcontrib-applehelp is a Sphinx extension which outputs Apple help books"
@@ -4057,4 +4031,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.13"
-content-hash = "1ef4d4a9e1ea554bb3afa58e8dd31374a6739ed56c3b2d4605fc4056a0a71ddf"
+content-hash = "fd40c9417c9b4620e5d9eb3075560871c65282672083290055008a38786803f8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2329,28 +2329,6 @@ files = [
 ]
 
 [[package]]
-name = "numpydoc"
-version = "1.6.0"
-description = "Sphinx extension to support docstrings in Numpy format"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "numpydoc-1.6.0-py3-none-any.whl", hash = "sha256:b6ddaa654a52bdf967763c1e773be41f1c3ae3da39ee0de973f2680048acafaa"},
-    {file = "numpydoc-1.6.0.tar.gz", hash = "sha256:ae7a5380f0a06373c3afe16ccd15bd79bc6b07f2704cbc6f1e7ecc94b4f5fc0d"},
-]
-
-[package.dependencies]
-Jinja2 = ">=2.10"
-sphinx = ">=5"
-tabulate = ">=0.8.10"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-
-[package.extras]
-developer = ["pre-commit (>=3.3)", "tomli"]
-doc = ["matplotlib (>=3.5)", "numpy (>=1.22)", "pydata-sphinx-theme (>=0.13.3)", "sphinx (>=7)"]
-test = ["matplotlib", "pytest", "pytest-cov"]
-
-[[package]]
 name = "overrides"
 version = "7.7.0"
 description = "A decorator to automatically detect mismatch when overriding a method."
@@ -2894,7 +2872,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -4080,4 +4057,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.13"
-content-hash = "dc58d5c52153eee4f3d5a01c3f88b0aa453d7c3ec5643fee923251090188ad3a"
+content-hash = "1ef4d4a9e1ea554bb3afa58e8dd31374a6739ed56c3b2d4605fc4056a0a71ddf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ optional = true
 [tool.poetry.group.docs.dependencies]
 sphinx = "^6.0.0"
 sphinx-book-theme = "^1.1.3"
-sphinxcontrib-apidoc = "^0.4.0"
 sphinx-copybutton = "^0.5.2"
 myst-nb = "^1.0.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ sphinx-book-theme = "^1.1.3"
 sphinxcontrib-apidoc = "^0.4.0"
 sphinx-copybutton = "^0.5.2"
 myst-nb = "^1.0.0"
-numpydoc = "^1.6.0"
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/AstarVienna/ScopeSim_Templates/issues"


### PR DESCRIPTION
Seems to work fine without the external apidoc thing.

The _templates were necessary to include function level docstring, see reference in one of the commit msgs.