### PR TITLE
Pass kwargs from star_field() to stars()

### DIFF
--- a/scopesim_templates/stellar/stars.py
+++ b/scopesim_templates/stellar/stars.py
@@ -88,7 +88,7 @@ def star_field(n, mmin, mmax, width, height=None, filter_name="V",
     spec_types = ["A0V"] * n
 
     src = stars(filter_name=filter_name, amplitudes=amplitudes,
-                spec_types=spec_types, x=x, y=y, ra=ra, dec=dec)
+                spec_types=spec_types, x=x, y=y, ra=ra, dec=dec, **kwargs)
     src.meta["scaling_unit"] = mmin.unit
     src.meta.update(params)
 


### PR DESCRIPTION
This allows to pass e.g. `library="kurucz"` to get spectra that actually cover the wavelength range of METIS 🙄 