### PR TITLE
flatlamp gets spectrum parameter; remove wrapper

### DIFF
--- a/scopesim_templates/micado/__init__.py
+++ b/scopesim_templates/micado/__init__.py
@@ -1,5 +1,6 @@
 from .darkness import darkness as _darkness
-from .flatlamp import flatlamp as _flatlamp
+#from .flatlamp import flatlamp as _flatlamp
+from .flatlamp import flatlamp
 from .pinhole_masks import pinhole_mask as _pinhole_mask
 from .cluster import cluster as _cluster
 from .viking_fields import viking_fields
@@ -19,9 +20,9 @@ def empty_sky():
     return _darkness()
 
 
-@add_function_call_str
-def flatlamp():
-    return _flatlamp()
+#@add_function_call_str
+#def flatlamp():
+#    return _flatlamp()
 
 
 @add_function_call_str


### PR DESCRIPTION
The primary change is the addition of a parameter `spectrum` to `flatlamp()`, allowing to set the lamp spectrum directly, thus avoiding constructions like the one that caused https://github.com/AstarVienna/ScopeSim/issues/565. 

To allow accessing this parameter (and also `fraction` and others) I have removed (commented out) the wrapper in `micado/__init__.py`. This was discussed in https://github.com/AstarVienna/ScopeSim_Templates/issues/123. To be honest I don't quite follow the reasoning there, but for the function to be useful the user must be able to see and set the parameters explicitely. 