### PR TITLE
Add padding option to `import_line_spectrum()`

### DIFF
--- a/scopesim_templates/micado/spectral_calibrations.py
+++ b/scopesim_templates/micado/spectral_calibrations.py
@@ -65,12 +65,14 @@ def line_list(unit_flux=1*PHOTLAM,
     if not isinstance(unit_flux, u.Quantity):
         unit_flux *= PHOTLAM
 
+    sigma = smoothing_fwhm / dwave / 2.35
+    ksize = int(8 * sigma + 1)
+
     # import line list and pad with zeros
-    wave, flux = import_line_spectrum(filename, dwave)
+    wave, flux = import_line_spectrum(filename, dwave, pad=ksize)
 
     if smoothing_fwhm is not None and isinstance(smoothing_fwhm, (int, float)):
-        sigma = smoothing_fwhm / dwave / 2.35
-        kernel = signal.windows.gaussian(M=int(8 * sigma + 1), std=sigma)
+        kernel = signal.windows.gaussian(M=ksize, std=sigma)
         kernel /= kernel.sum()
         flux = signal.convolve(flux, kernel, mode="same")
 
@@ -95,7 +97,7 @@ def line_list(unit_flux=1*PHOTLAM,
     return line_list_src
 
 
-def import_line_spectrum(filename, dwave=0.0001):
+def import_line_spectrum(filename, dwave=0.0001, pad=10):
     """
     Read in and pad the line list into a spectrum.
 
@@ -118,7 +120,7 @@ def import_line_spectrum(filename, dwave=0.0001):
     wave = line_tbl["Wavelength"].data
     wave = np.round(wave / dwave) * dwave       # round to level of dwave
     w0, w1 = wave[0], wave[-1]
-    wave_filled = np.arange(w0 - dwave, w1 + 2 * dwave, dwave)
+    wave_filled = np.arange(w0 - pad * dwave, w1 + pad * dwave, dwave)
     flux_filled = np.zeros_like(wave_filled)
 
     for w, f in zip(wave, flux):

--- a/scopesim_templates/micado/spectral_calibrations.py
+++ b/scopesim_templates/micado/spectral_calibrations.py
@@ -127,12 +127,11 @@ def import_line_spectrum(filename, dwave=0.0001, pad=10):
     flux = line_tbl["Relative_Intensity"].data
     wave = line_tbl["Wavelength"].data
     wave = np.round(wave / dwave) * dwave       # round to level of dwave
-    w0, w1 = wave[0], wave[-1]
-    wave_filled = np.arange(w0 - pad * dwave, w1 + pad * dwave, dwave)
+    padwave = pad * dwave
+    wave_filled = np.arange(wave.min() - padwave, wave.max() + padwave, dwave)
     flux_filled = np.zeros_like(wave_filled)
 
-    for w, f in zip(wave, flux):
-        i = int((w - w0) / dwave)
-        flux_filled[i] += f
+    indices = np.searchsorted(wave_filled, wave)
+    np.add.at(flux_filled, indices, flux)
 
     return wave_filled, flux_filled

--- a/scopesim_templates/micado/spectral_calibrations.py
+++ b/scopesim_templates/micado/spectral_calibrations.py
@@ -65,17 +65,12 @@ def line_list(unit_flux=1*PHOTLAM,
     if not isinstance(unit_flux, u.Quantity):
         unit_flux *= PHOTLAM
 
-    do_smoothing = False
-    ksize = 2
-    sigma = 1
-
-    if smoothing_fwhm is not None:
-        do_smoothing = True
-
     # calculate smoothing kernel size
-    if do_smoothing:
+    if do_smoothing := smoothing_fwhm is not None:
         sigma = smoothing_fwhm / dwave / 2.35
         ksize = int(8 * sigma + 1)
+    else:
+        ksize = 2
 
     # import line list and pad with zeros
     # (including smoothing kernel space at the edges)

--- a/scopesim_templates/micado/spectral_calibrations.py
+++ b/scopesim_templates/micado/spectral_calibrations.py
@@ -69,7 +69,7 @@ def line_list(unit_flux=1*PHOTLAM,
     ksize = 2
     sigma = 1
 
-    if smoothing_fwhm is not None and isinstance(smoothing_fwhm, (int, float)):
+    if smoothing_fwhm is not None:
         do_smoothing = True
 
     # calculate smoothing kernel size

--- a/scopesim_templates/micado/spectral_calibrations.py
+++ b/scopesim_templates/micado/spectral_calibrations.py
@@ -65,14 +65,23 @@ def line_list(unit_flux=1*PHOTLAM,
     if not isinstance(unit_flux, u.Quantity):
         unit_flux *= PHOTLAM
 
-    sigma = smoothing_fwhm / dwave / 2.35
-    ksize = int(8 * sigma + 1)
+    do_smoothing = False
+    ksize = 2
+    sigma = 1
+
+    if smoothing_fwhm is not None and isinstance(smoothing_fwhm, (int, float)):
+        do_smoothing = True
+
+    # calculate smoothing kernel size
+    if do_smoothing:
+        sigma = smoothing_fwhm / dwave / 2.35
+        ksize = int(8 * sigma + 1)
 
     # import line list and pad with zeros
     # (including smoothing kernel space at the edges)
     wave, flux = import_line_spectrum(filename, dwave, pad=ksize)
 
-    if smoothing_fwhm is not None and isinstance(smoothing_fwhm, (int, float)):
+    if do_smoothing:
         kernel = signal.windows.gaussian(M=ksize, std=sigma)
         kernel /= kernel.sum()
         flux = signal.convolve(flux, kernel, mode="same")

--- a/scopesim_templates/micado/spectral_calibrations.py
+++ b/scopesim_templates/micado/spectral_calibrations.py
@@ -69,6 +69,7 @@ def line_list(unit_flux=1*PHOTLAM,
     ksize = int(8 * sigma + 1)
 
     # import line list and pad with zeros
+    # (including smoothing kernel space at the edges)
     wave, flux = import_line_spectrum(filename, dwave, pad=ksize)
 
     if smoothing_fwhm is not None and isinstance(smoothing_fwhm, (int, float)):
@@ -105,6 +106,13 @@ def import_line_spectrum(filename, dwave=0.0001, pad=10):
     ----------
     filename : str
         Name of line list file found in ``micado/data``
+
+    dwave : float
+        Bin width in units of input file
+
+    pad : int
+        Padding in wavelength range to add to allow enough space for smoothing
+        function kernel
 
     Returns
     -------

--- a/scopesim_templates/tests/test_micado/test_spectral_calibrations.py
+++ b/scopesim_templates/tests/test_micado/test_spectral_calibrations.py
@@ -45,6 +45,7 @@ class TestLineList:
         flux1 = src1.spectra[0](wave).value
         flux2 = src2.spectra[0](wave).value
 
+        assert wave[flux1.argmax()].value == approx(wave[flux2.argmax()].value, rel=1e-6)
         assert flux1.max() > flux2.max()
         assert flux1.sum() == approx(flux2.sum(), rel=2e-2)
 


### PR DESCRIPTION
Added optional pad= parameter when reading in linelist to avoid the smoothing ending on non-zero flux level.