### PR TITLE
micado.flatlamp(): Change default field size

### DIFF
--- a/scopesim_templates/micado/flatlamp.py
+++ b/scopesim_templates/micado/flatlamp.py
@@ -8,8 +8,8 @@ from ..rc import Source
 
 
 def flatlamp(
-        width=16.384,
-        height=16.384,
+        width=21.0,
+        height=21.0,
         pixel_scale=1.024,
         amplitude=1000.0,
         fraction=0.9,


### PR DESCRIPTION
micado.flatlamp(): Change default size of flatlamp to cover the full MICADO longslit that extends up-to 10 arcsec off axis.

Also - the parameters for these functions are 'hidden' by `__init__.py` by the need to channel the function call via `@add_function_call_str` - how can we avoid this?