### PR TITLE
Make ScopeSim_Templates test work without internet with -m "not webtest"

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,13 @@ jobs:
       poetry: True
     secrets: inherit
 
+  call-webtests:
+    name: Network tests
+    uses: AstarVienna/DevOps/.github/workflows/webtests.yml@main
+    with:
+      poetry: True
+    secrets: inherit
+
   call-updated-tests:
     name: Tests with updated dependencies
     uses: AstarVienna/DevOps/.github/workflows/updated_tests.yml@main

--- a/scopesim_templates/stellar/cluster_utils.py
+++ b/scopesim_templates/stellar/cluster_utils.py
@@ -13,28 +13,73 @@ import pyckles
 
 
 DIRNAME = Path(__file__).parent
-MAMAJEK = Table.read(DIRNAME / "mamajek_alt.dat", format="ascii.fixed_width")
 
-# Catalog 2 contains only main sequence anyway
-tbl = pyckles.SpectralLibrary("pickles").catalog[2].data
-PICKLES_MS_V = tbl["name"][tbl["metalicity"] == "normal"]
 
-# Only include Spectral Types for which Pickles has an entry
-MAMAJEK_PICKLES = MAMAJEK[[spt in PICKLES_MS_V for spt in MAMAJEK["SpT"]]]
-F_MASS2MV = interp1d(
-    MAMAJEK_PICKLES["Msun"],
-    MAMAJEK_PICKLES["Mv"],
-    kind=1,
-    # bounds_error=False,
-    fill_value="extrapolate",
-)
-F_MASS2IDX = interp1d(
-    MAMAJEK_PICKLES["Msun"],
-    range(len(MAMAJEK_PICKLES)),
-    kind=0,
-    bounds_error=False,
-    fill_value=(len(MAMAJEK_PICKLES) - 1, 0),
-)
+class ClusterUtilSingletons:
+    """Singletons that usually require the internet."""
+
+    _mamajek = None
+    _pickles_ms_v = None
+    _mamajek_pickles = None
+    _f_mass2mv = None
+    _f_mass2idx = None
+
+    def fill_singletons(self):
+        if self._mamajek is not None:
+            return
+
+        self._mamajek = Table.read(DIRNAME / "mamajek_alt.dat", format="ascii.fixed_width")
+
+        # Catalog 2 contains only main sequence anyway
+        tbl = pyckles.SpectralLibrary("pickles").catalog[2].data
+        self._pickles_ms_v = tbl["name"][tbl["metalicity"] == "normal"]
+
+        # Only include Spectral Types for which Pickles has an entry
+        self._mamajek_pickles = self._mamajek[[spt in self._pickles_ms_v for spt in self._mamajek["SpT"]]]
+
+        self._f_mass2mv = interp1d(
+            self._mamajek_pickles["Msun"],
+            self._mamajek_pickles["Mv"],
+            kind=1,
+            # bounds_error=False,
+            fill_value="extrapolate",
+        )
+
+        self._f_mass2idx = interp1d(
+            self._mamajek_pickles["Msun"],
+            range(len(self._mamajek_pickles)),
+            kind=0,
+            bounds_error=False,
+            fill_value=(len(self._mamajek_pickles) - 1, 0),
+        )
+
+    @property
+    def mamajek(self):
+        self.fill_singletons()
+        return self._mamajek
+
+    @property
+    def pickles_ms_v(self):
+        self.fill_singletons()
+        return self._pickles_ms_v
+
+    @property
+    def mamajek_pickles(self) -> np.ndarray:
+        self.fill_singletons()
+        return self._mamajek_pickles
+
+    @property
+    def f_mass2mv(self):
+        self.fill_singletons()
+        return self._f_mass2mv
+
+    @property
+    def f_mass2idx(self):
+        self.fill_singletons()
+        return self._f_mass2idx
+
+
+CLUSTER_UTIL_SINGLETONS = ClusterUtilSingletons()
 
 
 def mass2spt(mass):
@@ -59,8 +104,8 @@ def mass2spt(mass):
     if isinstance(mass, Iterable):
         mass = np.asarray(mass)
 
-    idx = F_MASS2IDX(mass).astype(int)
-    return MAMAJEK_PICKLES["SpT"][idx]
+    idx = CLUSTER_UTIL_SINGLETONS.f_mass2idx(mass).astype(int)
+    return CLUSTER_UTIL_SINGLETONS.mamajek_pickles["SpT"][idx]
 
 
 def mass2absmag(mass):
@@ -83,9 +128,9 @@ def mass2absmag(mass):
 
     """
     if isinstance(mass, Iterable):
-        return F_MASS2MV(np.asarray(mass)).round(3)
+        return CLUSTER_UTIL_SINGLETONS.f_mass2mv(np.asarray(mass)).round(3)
     # Round to match interpolation precision, float to not have array.
-    return float(F_MASS2MV(mass).round(3))
+    return float(CLUSTER_UTIL_SINGLETONS.f_mass2mv(mass).round(3))
 
 
 def closest_pickles(spt):
@@ -109,7 +154,7 @@ def closest_pickles(spt):
 
     to_strip = "OBAFGKMIV "
 
-    lum_types = PICKLES_MS_V[PICKLES_MS_V.startswith(spt[0])]
+    lum_types = CLUSTER_UTIL_SINGLETONS.pickles_ms_v[CLUSTER_UTIL_SINGLETONS.pickles_ms_v.startswith(spt[0])]
     assert lum_types.strip(to_strip).isdigit().all()
     # The join is necessary to correctly parse 'M25V' as 2.5 and not 25...
     num_only = np.char.join(".", lum_types.strip(to_strip))

--- a/scopesim_templates/tests/test_calibration/test_calibration.py
+++ b/scopesim_templates/tests/test_calibration/test_calibration.py
@@ -1,3 +1,4 @@
+import pytest
 from astropy.io.fits import ImageHDU
 from astropy.table import Table
 from astropy import units as u
@@ -18,6 +19,7 @@ class TestEmptySky:
 
 
 class TestFlatField:
+    @pytest.mark.webtest
     def test_flat_field_returns_source_object(self):
         flatfield = calibration.calibration.flat_field()
         assert isinstance(flatfield, Source)

--- a/scopesim_templates/tests/test_extragalactic/test_galaxy.py
+++ b/scopesim_templates/tests/test_extragalactic/test_galaxy.py
@@ -13,6 +13,7 @@ PLOTS = False
 
 
 class TestGalaxy:
+    @pytest.mark.webtest
     def test_redshift(self):
         sp0 = galaxies.galaxy("kc96/s0", z=0, amplitude=10*u.ABmag,
                               filter_curve="g", pixel_scale=0.05, r_eff=2.5,
@@ -24,6 +25,7 @@ class TestGalaxy:
         kwargs = {"filter_curve": "g", "system_name": "AB"}
         assert sp0.get_magnitude(**kwargs) == sp1.get_magnitude(**kwargs)
 
+    @pytest.mark.webtest
     @pytest.mark.parametrize("amp", [10*u.ABmag, 15*u.ABmag, 20*u.ABmag])
     def test_scaling(self, amp):
         gal = galaxies.galaxy("kc96/s0", z=0, amplitude=amp,
@@ -34,6 +36,7 @@ class TestGalaxy:
 
 
 class TestElliptical:
+    @pytest.mark.webtest
     def test_it_works(self):
         gal = galaxies.elliptical(125, 1, "V", 10 * u.ABmag, n=1,
                                   spectrum="NGC_0584")

--- a/scopesim_templates/tests/test_micado/test_cluster.py
+++ b/scopesim_templates/tests/test_micado/test_cluster.py
@@ -1,6 +1,7 @@
 """Test cluster."""
 
 from astropy.table import Table
+import pytest
 from synphot import SourceSpectrum
 
 from scopesim_templates.micado import cluster
@@ -10,6 +11,7 @@ from scopesim_templates.rc import Source
 class TestCluster:
     """Test cluster."""
 
+    @pytest.mark.webtest
     def test_cluster_returns_source_object(self):
         """Test cluster."""
         sky = cluster()

--- a/scopesim_templates/tests/test_micado/test_viking_fields.py
+++ b/scopesim_templates/tests/test_micado/test_viking_fields.py
@@ -12,6 +12,7 @@ PLOTS = False
 
 
 class TestVikingCatalogues:
+    @pytest.mark.webtest
     @pytest.mark.parametrize("cat_id", [("1"), ("2"), ("3")])
     def test_load_galaxies_source(self, cat_id):
         gal_src = vf.load_galaxies_source(cat_id)
@@ -27,6 +28,7 @@ class TestVikingCatalogues:
         assert len(gal_src.fields) > 1
         assert len(gal_src.spectra) == 1
 
+    @pytest.mark.webtest
     @pytest.mark.parametrize("cat_id",
                              [("stdstar"),
                               ("illum"),
@@ -46,6 +48,7 @@ class TestVikingCatalogues:
         assert len(star_src.fields[0]) > 1
         assert len(star_src.spectra) == 1
 
+    @pytest.mark.webtest
     def test_load_viking_field(self):
         viking_src = vf.viking_field()
 
@@ -67,6 +70,7 @@ class TestVikingCatalogues:
 
 
 class TestWithScopeSim:
+    @pytest.mark.webtest
     def test_runs_through_scopesim_basic_instrument(self):
         # configure basic_instrument to MICADO specs
         opt = load_example_optical_train()

--- a/scopesim_templates/tests/test_misc/test_misc.py
+++ b/scopesim_templates/tests/test_misc/test_misc.py
@@ -145,6 +145,7 @@ class TestSourceFromImageHDU:
 
 
 class TestPointSource:
+    @pytest.mark.webtest
     def test_initialize_from_spextra(self):
         src = misc.point_source("pickles/a0v", amplitude=16)
 
@@ -157,6 +158,7 @@ class TestPointSource:
 
 
 class TestUniformSource:
+    @pytest.mark.webtest
     def test_initialize_from_spextra(self):
         src = misc.uniform_source("pickles/a0v", amplitude=16)
 

--- a/scopesim_templates/tests/test_stellar/test_cluster_utils.py
+++ b/scopesim_templates/tests/test_stellar/test_cluster_utils.py
@@ -4,20 +4,23 @@ import numpy as np
 from astropy.table import Table
 
 import scopesim_templates.stellar.cluster_utils as cu
+from scopesim_templates.stellar.cluster_utils import CLUSTER_UTIL_SINGLETONS as cus
 
 from matplotlib import pyplot as plt
 
 PLOTS = False
 
 
+@mark.webtest
 class TestCatExists:
     def test_cat_is_table(self):
-        assert isinstance(cu.MAMAJEK, Table)
+        assert isinstance(cus.mamajek, Table)
 
     def test_cat_is_nonempty(self):
-        assert len(cu.MAMAJEK) > 0
+        assert len(cus.mamajek) > 0
 
 
+@mark.webtest
 class TestMass2AbsMag:
     @mark.parametrize("mass, mv, atol",
                       [(2.3, 1.11, 0.1),
@@ -31,6 +34,7 @@ class TestMass2AbsMag:
         assert mvs[1] == approx(4.79, rel=0.01)
 
 
+@mark.webtest
 class TestMass2SpT:
     @mark.parametrize("mass, spt",
                       [(250, "O5V"),
@@ -46,6 +50,7 @@ class TestMass2SpT:
         assert isinstance(spts, np.ndarray)
 
 
+@mark.webtest
 class TestClosestPickles:
     @mark.parametrize("spt_in, spt_out",
                       [("O1V", "O5V"),

--- a/scopesim_templates/tests/test_stellar/test_clusters.py
+++ b/scopesim_templates/tests/test_stellar/test_clusters.py
@@ -18,15 +18,18 @@ def basic_cluster():
 
 
 class TestCluster:
+    @pytest.mark.webtest
     @pytest.mark.usefixtures("basic_cluster")
     def test_it_works(self, basic_cluster):
         assert isinstance(basic_cluster, Source)
 
+    @pytest.mark.webtest
     @pytest.mark.usefixtures("basic_cluster")
     def test_spectra_are_correct_type(self, basic_cluster):
         assert all(isinstance(spec, Spextrum)
                    for spec in basic_cluster.spectra.values())
 
+    @pytest.mark.webtest
     @pytest.mark.usefixtures("basic_cluster")
     def test_spectra_waverange(self, basic_cluster):
         # TODO: don't know if it makes sense to test like this
@@ -37,11 +40,13 @@ class TestCluster:
         assert all(wave == approx(0.115) for wave in wvrng_min)
         assert all(wave == approx(2.5) for wave in wvrng_max)
 
+    @pytest.mark.webtest
     @pytest.mark.usefixtures("basic_cluster")
     def test_field_is_correct_type(self, basic_cluster):
         assert isinstance(basic_cluster.fields[0].field, Table)
         assert len(basic_cluster.fields[0]) > 0
 
+    @pytest.mark.webtest
     @pytest.mark.usefixtures("basic_cluster")
     def test_as_many_spectra_as_unique_sptypes(self, basic_cluster):
         uniques = set(basic_cluster.fields[0]["spec_types"])

--- a/scopesim_templates/tests/test_stellar/test_star_utils.py
+++ b/scopesim_templates/tests/test_stellar/test_star_utils.py
@@ -10,6 +10,7 @@ def pickles():
     return pyckles.SpectralLibrary("pickles")
 
 
+@pytest.mark.webtest
 @pytest.mark.usefixtures("pickles")
 class TestNearestSpecType:
     @pytest.mark.parametrize("spec_types", ("A0V", "G2V",

--- a/scopesim_templates/tests/test_stellar/test_stars.py
+++ b/scopesim_templates/tests/test_stellar/test_stars.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest import approx
 import numpy as np
 
@@ -18,6 +19,7 @@ def source_eq(source_lhs: Source, source_rhs: Source):
 
 
 class TestStar:
+    @pytest.mark.webtest
     def test_star_stars_equivalent(self):
         """verify that star and stars yield the same object and have compatible interfaces"""
         src_from_star = star("Generic/Johnson.V", 0, "A0V", 0, 0)
@@ -31,6 +33,7 @@ class TestStar:
         assert source_eq(src_from_star, src_from_stars_unit)
 
 
+@pytest.mark.webtest
 class TestStars:
     def test_returns_correct_photon_counts_when_scaled_to_vega_zero(self):
         src = stars("Generic/Johnson.V", [0]*u.mag, ["A0V"], [0], [0])
@@ -64,12 +67,14 @@ class TestStars:
         assert np.all(src.fields[0]["weight"] == 1)
 
 
+@pytest.mark.webtest
 class TestStarField:
     def test_returns_source_object_with_minimal_input(self):
         src = star_field(n=2, mmin=0, mmax=5, width=1)
         assert isinstance(src, Source)
 
 
+@pytest.mark.webtest
 class TestStarGrid:
     def test_returns_source_object_with_correct_weighting_without_unit(self):
         src = star_grid(n=3, mmin=0, mmax=5)

--- a/scopesim_templates/tests/test_utils/test_cleared_cache.py
+++ b/scopesim_templates/tests/test_utils/test_cleared_cache.py
@@ -1,7 +1,10 @@
+import pytest
+
 from scopesim_templates import cluster
 from scopesim_templates.rc import Source
 
 
+@pytest.mark.webtest
 def test_actually_works():
     my_cluster = cluster(mass=900, distance=50000, core_radius=1)
     assert isinstance(my_cluster, Source)

--- a/scopesim_templates/tests/test_utils/test_validate_content.py
+++ b/scopesim_templates/tests/test_utils/test_validate_content.py
@@ -10,75 +10,90 @@ from scopesim_templates.stellar import star
 from scopesim_templates.extragalactic import galaxy, galaxy3d, spiral_two_component
 from scopesim_templates.misc.misc import source_from_array
 
-# Add all initialied examples of sources to be tested to this list
-SOURCE_LIST = [star(filter_name="Ks", amplitude=10*u.mag),
-               star(filter_name="Paranal/HAWKI.J", amplitude=10*u.Jansky),
-               spiral_two_component(),
-               galaxy(sed="kc96/s0"),
-               galaxy3d(sed="kc96/s0", ngrid=10),
-               source_from_array(arr=np.ones(shape=(100, 100)),
-                                 sed="kc96/s0",
-                                 amplitude=15,
-                                 pixel_scale=0.2,
-                                 filter_curve="g")
-               ]
+
+@pytest.fixture(scope="module")
+def source_list():
+    """All initialized examples of sources to be tested"""
+    return [
+        star(filter_name="Ks", amplitude=10*u.mag),
+        star(filter_name="Paranal/HAWKI.J", amplitude=10*u.Jansky),
+        spiral_two_component(),
+        galaxy(sed="kc96/s0"),
+        galaxy3d(sed="kc96/s0", ngrid=10),
+        source_from_array(
+            arr=np.ones(shape=(100, 100)),
+            sed="kc96/s0",
+            amplitude=15,
+            pixel_scale=0.2,
+            filter_curve="g",
+        ),
+    ]
 
 
 # Run all tests on each source indivdually
-@pytest.mark.parametrize("src", SOURCE_LIST)
+@pytest.mark.webtest
+@pytest.mark.usefixtures("source_list")
 class TestContentOfFields:
     """Test the <Source>.fields attribute to check that the content is correct."""
 
-    def test_is_fields_a_list(self, src):
-        assert isinstance(src.fields, list)
+    def test_is_fields_a_list(self, source_list):
+        for src in source_list:
+            assert isinstance(src.fields, list)
 
-    def test_fields_list_has_only_imagehdus_or_tables(self, src):
-        for field in src.fields:
-            if not isinstance(field, Table):
-                assert isinstance(field.field, (Table, ImageHDU))
+    def test_fields_list_has_only_imagehdus_or_tables(self, source_list):
+        for src in source_list:
+            for field in src.fields:
+                if not isinstance(field, Table):
+                    assert isinstance(field.field, (Table, ImageHDU))
 
-    def test_any_tables_have_correct_column_names(self, src):
-        for field in src.fields:
-            if not isinstance(field, Table):
-                continue
-            req_colnames = ["x", "y", "ref", "weight"]
-            assert all(col in field.field.colnames for col in req_colnames)
+    def test_any_tables_have_correct_column_names(self, source_list):
+        for src in source_list:
+            for field in src.fields:
+                if not isinstance(field, Table):
+                    continue
+                req_colnames = ["x", "y", "ref", "weight"]
+                assert all(col in field.field.colnames for col in req_colnames)
 
-    def test_any_imagehdus_have_correct_header_keywords(self, src):
-        for field in src.fields:
-            if isinstance(field.field, ImageHDU):
-                req_keys = ["SPEC_REF", "NAXIS", "NAXIS1", "NAXIS2",
-                            "CUNIT1", "CUNIT2", "CTYPE1", "CTYPE2",
-                            "CDELT1", "CDELT2", "CRVAL1", "CRVAL2",
-                            "CRPIX1", "CRPIX2"]
-                assert all(key in field.header for key in req_keys)
+    def test_any_imagehdus_have_correct_header_keywords(self, source_list):
+        for src in source_list:
+            for field in src.fields:
+                if isinstance(field.field, ImageHDU):
+                    req_keys = ["SPEC_REF", "NAXIS", "NAXIS1", "NAXIS2",
+                                "CUNIT1", "CUNIT2", "CTYPE1", "CTYPE2",
+                                "CDELT1", "CDELT2", "CRVAL1", "CRVAL2",
+                                "CRPIX1", "CRPIX2"]
+                    assert all(key in field.header for key in req_keys)
 
 
-@pytest.mark.parametrize("src", SOURCE_LIST)
+@pytest.mark.webtest
 class TestContentOfSpectra:
     """Test the <Source>.spectra attribute to check that all spectra are useful."""
 
-    def test_is_spectra_a_list_or_dict(self, src):
-        # ScopeSim pre-0.9 is a list, afterwards dict. Allow both here.
-        assert isinstance(src.spectra, (list, dict))
+    def test_is_spectra_a_list_or_dict(self, source_list):
+        for src in source_list:
+            # ScopeSim pre-0.9 is a list, afterwards dict. Allow both here.
+            assert isinstance(src.spectra, (list, dict))
 
-    def test_spectra_list_has_only_synphot_sourcespectrum_objects(self, src):
-        for spectrum in src.spectra.values():
-            assert isinstance(spectrum, SourceSpectrum)
+    def test_spectra_list_has_only_synphot_sourcespectrum_objects(self, source_list):
+        for src in source_list:
+            for spectrum in src.spectra.values():
+                assert isinstance(spectrum, SourceSpectrum)
 
 
-@pytest.mark.parametrize("src", SOURCE_LIST)
+@pytest.mark.webtest
 class TestConnectionBetweenFieldsAndSpectra:
     """Test that all spectra referenced by .fields are in .spectra."""
 
-    def test_all_spectra_in_table_ref_column_exist(self, src):
-        for field in src.fields:
-            if isinstance(field.field, Table):
-                for ref in field["ref"]:
-                    assert isinstance(src.spectra[ref], SourceSpectrum)
+    def test_all_spectra_in_table_ref_column_exist(self, source_list):
+        for src in source_list:
+            for field in src.fields:
+                if isinstance(field.field, Table):
+                    for ref in field["ref"]:
+                        assert isinstance(src.spectra[ref], SourceSpectrum)
 
-    def test_all_spectra_refereced_in_imagehdu_header_exist(self, src):
-        for field in src.fields:
-            if isinstance(field.field, ImageHDU):
-                ref = field.header["SPEC_REF"]
-                assert isinstance(src.spectra[ref], SourceSpectrum)
+    def test_all_spectra_refereced_in_imagehdu_header_exist(self, source_list):
+        for src in source_list:
+            for field in src.fields:
+                if isinstance(field.field, ImageHDU):
+                    ref = field.header["SPEC_REF"]
+                    assert isinstance(src.spectra[ref], SourceSpectrum)


### PR DESCRIPTION
Significant changes to cluster_utils, but that is not used outside of ScopeSim_Templates, so that should be fine.

A bit refactoring in test_validate_content because paramaterized fixtures do not exist in pytest.

And a lot of webtest markers.

Verified that no internet is required in a guix container without internet.

Close #117 and #131.