### PR TITLE
Replace `ter_curves_utils` functions with spextra equivalents

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2609,6 +2609,7 @@ description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "python_version < \"3.13\""
 files = [
     {file = "numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb"},
     {file = "numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90"},
@@ -2665,6 +2666,91 @@ files = [
     {file = "numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543"},
     {file = "numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00"},
     {file = "numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd"},
+]
+
+[[package]]
+name = "numpy"
+version = "2.3.5"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+markers = "python_version >= \"3.13\""
+files = [
+    {file = "numpy-2.3.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:de5672f4a7b200c15a4127042170a694d4df43c992948f5e1af57f0174beed10"},
+    {file = "numpy-2.3.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:acfd89508504a19ed06ef963ad544ec6664518c863436306153e13e94605c218"},
+    {file = "numpy-2.3.5-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:ffe22d2b05504f786c867c8395de703937f934272eb67586817b46188b4ded6d"},
+    {file = "numpy-2.3.5-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:872a5cf366aec6bb1147336480fef14c9164b154aeb6542327de4970282cd2f5"},
+    {file = "numpy-2.3.5-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3095bdb8dd297e5920b010e96134ed91d852d81d490e787beca7e35ae1d89cf7"},
+    {file = "numpy-2.3.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8cba086a43d54ca804ce711b2a940b16e452807acebe7852ff327f1ecd49b0d4"},
+    {file = "numpy-2.3.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6cf9b429b21df6b99f4dee7a1218b8b7ffbbe7df8764dc0bd60ce8a0708fed1e"},
+    {file = "numpy-2.3.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:396084a36abdb603546b119d96528c2f6263921c50df3c8fd7cb28873a237748"},
+    {file = "numpy-2.3.5-cp311-cp311-win32.whl", hash = "sha256:b0c7088a73aef3d687c4deef8452a3ac7c1be4e29ed8bf3b366c8111128ac60c"},
+    {file = "numpy-2.3.5-cp311-cp311-win_amd64.whl", hash = "sha256:a414504bef8945eae5f2d7cb7be2d4af77c5d1cb5e20b296c2c25b61dff2900c"},
+    {file = "numpy-2.3.5-cp311-cp311-win_arm64.whl", hash = "sha256:0cd00b7b36e35398fa2d16af7b907b65304ef8bb4817a550e06e5012929830fa"},
+    {file = "numpy-2.3.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:74ae7b798248fe62021dbf3c914245ad45d1a6b0cb4a29ecb4b31d0bfbc4cc3e"},
+    {file = "numpy-2.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ee3888d9ff7c14604052b2ca5535a30216aa0a58e948cdd3eeb8d3415f638769"},
+    {file = "numpy-2.3.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:612a95a17655e213502f60cfb9bf9408efdc9eb1d5f50535cc6eb365d11b42b5"},
+    {file = "numpy-2.3.5-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:3101e5177d114a593d79dd79658650fe28b5a0d8abeb8ce6f437c0e6df5be1a4"},
+    {file = "numpy-2.3.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b973c57ff8e184109db042c842423ff4f60446239bd585a5131cc47f06f789d"},
+    {file = "numpy-2.3.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d8163f43acde9a73c2a33605353a4f1bc4798745a8b1d73183b28e5b435ae28"},
+    {file = "numpy-2.3.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:51c1e14eb1e154ebd80e860722f9e6ed6ec89714ad2db2d3aa33c31d7c12179b"},
+    {file = "numpy-2.3.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b46b4ec24f7293f23adcd2d146960559aaf8020213de8ad1909dba6c013bf89c"},
+    {file = "numpy-2.3.5-cp312-cp312-win32.whl", hash = "sha256:3997b5b3c9a771e157f9aae01dd579ee35ad7109be18db0e85dbdbe1de06e952"},
+    {file = "numpy-2.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:86945f2ee6d10cdfd67bcb4069c1662dd711f7e2a4343db5cecec06b87cf31aa"},
+    {file = "numpy-2.3.5-cp312-cp312-win_arm64.whl", hash = "sha256:f28620fe26bee16243be2b7b874da327312240a7cdc38b769a697578d2100013"},
+    {file = "numpy-2.3.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d0f23b44f57077c1ede8c5f26b30f706498b4862d3ff0a7298b8411dd2f043ff"},
+    {file = "numpy-2.3.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa5bc7c5d59d831d9773d1170acac7893ce3a5e130540605770ade83280e7188"},
+    {file = "numpy-2.3.5-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ccc933afd4d20aad3c00bcef049cb40049f7f196e0397f1109dba6fed63267b0"},
+    {file = "numpy-2.3.5-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afaffc4393205524af9dfa400fa250143a6c3bc646c08c9f5e25a9f4b4d6a903"},
+    {file = "numpy-2.3.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c75442b2209b8470d6d5d8b1c25714270686f14c749028d2199c54e29f20b4d"},
+    {file = "numpy-2.3.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:11e06aa0af8c0f05104d56450d6093ee639e15f24ecf62d417329d06e522e017"},
+    {file = "numpy-2.3.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ed89927b86296067b4f81f108a2271d8926467a8868e554eaf370fc27fa3ccaf"},
+    {file = "numpy-2.3.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51c55fe3451421f3a6ef9a9c1439e82101c57a2c9eab9feb196a62b1a10b58ce"},
+    {file = "numpy-2.3.5-cp313-cp313-win32.whl", hash = "sha256:1978155dd49972084bd6ef388d66ab70f0c323ddee6f693d539376498720fb7e"},
+    {file = "numpy-2.3.5-cp313-cp313-win_amd64.whl", hash = "sha256:00dc4e846108a382c5869e77c6ed514394bdeb3403461d25a829711041217d5b"},
+    {file = "numpy-2.3.5-cp313-cp313-win_arm64.whl", hash = "sha256:0472f11f6ec23a74a906a00b48a4dcf3849209696dff7c189714511268d103ae"},
+    {file = "numpy-2.3.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:414802f3b97f3c1eef41e530aaba3b3c1620649871d8cb38c6eaff034c2e16bd"},
+    {file = "numpy-2.3.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5ee6609ac3604fa7780e30a03e5e241a7956f8e2fcfe547d51e3afa5247ac47f"},
+    {file = "numpy-2.3.5-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:86d835afea1eaa143012a2d7a3f45a3adce2d7adc8b4961f0b362214d800846a"},
+    {file = "numpy-2.3.5-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:30bc11310e8153ca664b14c5f1b73e94bd0503681fcf136a163de856f3a50139"},
+    {file = "numpy-2.3.5-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1062fde1dcf469571705945b0f221b73928f34a20c904ffb45db101907c3454e"},
+    {file = "numpy-2.3.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ce581db493ea1a96c0556360ede6607496e8bf9b3a8efa66e06477267bc831e9"},
+    {file = "numpy-2.3.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:cc8920d2ec5fa99875b670bb86ddeb21e295cb07aa331810d9e486e0b969d946"},
+    {file = "numpy-2.3.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:9ee2197ef8c4f0dfe405d835f3b6a14f5fee7782b5de51ba06fb65fc9b36e9f1"},
+    {file = "numpy-2.3.5-cp313-cp313t-win32.whl", hash = "sha256:70b37199913c1bd300ff6e2693316c6f869c7ee16378faf10e4f5e3275b299c3"},
+    {file = "numpy-2.3.5-cp313-cp313t-win_amd64.whl", hash = "sha256:b501b5fa195cc9e24fe102f21ec0a44dffc231d2af79950b451e0d99cea02234"},
+    {file = "numpy-2.3.5-cp313-cp313t-win_arm64.whl", hash = "sha256:a80afd79f45f3c4a7d341f13acbe058d1ca8ac017c165d3fa0d3de6bc1a079d7"},
+    {file = "numpy-2.3.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:bf06bc2af43fa8d32d30fae16ad965663e966b1a3202ed407b84c989c3221e82"},
+    {file = "numpy-2.3.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:052e8c42e0c49d2575621c158934920524f6c5da05a1d3b9bab5d8e259e045f0"},
+    {file = "numpy-2.3.5-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:1ed1ec893cff7040a02c8aa1c8611b94d395590d553f6b53629a4461dc7f7b63"},
+    {file = "numpy-2.3.5-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:2dcd0808a421a482a080f89859a18beb0b3d1e905b81e617a188bd80422d62e9"},
+    {file = "numpy-2.3.5-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727fd05b57df37dc0bcf1a27767a3d9a78cbbc92822445f32cc3436ba797337b"},
+    {file = "numpy-2.3.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fffe29a1ef00883599d1dc2c51aa2e5d80afe49523c261a74933df395c15c520"},
+    {file = "numpy-2.3.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8f7f0e05112916223d3f438f293abf0727e1181b5983f413dfa2fefc4098245c"},
+    {file = "numpy-2.3.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2e2eb32ddb9ccb817d620ac1d8dae7c3f641c1e5f55f531a33e8ab97960a75b8"},
+    {file = "numpy-2.3.5-cp314-cp314-win32.whl", hash = "sha256:66f85ce62c70b843bab1fb14a05d5737741e74e28c7b8b5a064de10142fad248"},
+    {file = "numpy-2.3.5-cp314-cp314-win_amd64.whl", hash = "sha256:e6a0bc88393d65807d751a614207b7129a310ca4fe76a74e5c7da5fa5671417e"},
+    {file = "numpy-2.3.5-cp314-cp314-win_arm64.whl", hash = "sha256:aeffcab3d4b43712bb7a60b65f6044d444e75e563ff6180af8f98dd4b905dfd2"},
+    {file = "numpy-2.3.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17531366a2e3a9e30762c000f2c43a9aaa05728712e25c11ce1dbe700c53ad41"},
+    {file = "numpy-2.3.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d21644de1b609825ede2f48be98dfde4656aefc713654eeee280e37cadc4e0ad"},
+    {file = "numpy-2.3.5-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c804e3a5aba5460c73955c955bdbd5c08c354954e9270a2c1565f62e866bdc39"},
+    {file = "numpy-2.3.5-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:cc0a57f895b96ec78969c34f682c602bf8da1a0270b09bc65673df2e7638ec20"},
+    {file = "numpy-2.3.5-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:900218e456384ea676e24ea6a0417f030a3b07306d29d7ad843957b40a9d8d52"},
+    {file = "numpy-2.3.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:09a1bea522b25109bf8e6f3027bd810f7c1085c64a0c7ce050c1676ad0ba010b"},
+    {file = "numpy-2.3.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:04822c00b5fd0323c8166d66c701dc31b7fbd252c100acd708c48f763968d6a3"},
+    {file = "numpy-2.3.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d6889ec4ec662a1a37eb4b4fb26b6100841804dac55bd9df579e326cdc146227"},
+    {file = "numpy-2.3.5-cp314-cp314t-win32.whl", hash = "sha256:93eebbcf1aafdf7e2ddd44c2923e2672e1010bddc014138b229e49725b4d6be5"},
+    {file = "numpy-2.3.5-cp314-cp314t-win_amd64.whl", hash = "sha256:c8a9958e88b65c3b27e22ca2a076311636850b612d6bbfb76e8d156aacde2aaf"},
+    {file = "numpy-2.3.5-cp314-cp314t-win_arm64.whl", hash = "sha256:6203fdf9f3dc5bdaed7319ad8698e685c7a3be10819f41d32a0723e611733b42"},
+    {file = "numpy-2.3.5-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:f0963b55cdd70fad460fa4c1341f12f976bb26cb66021a5580329bd498988310"},
+    {file = "numpy-2.3.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f4255143f5160d0de972d28c8f9665d882b5f61309d8362fdd3e103cf7bf010c"},
+    {file = "numpy-2.3.5-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:a4b9159734b326535f4dd01d947f919c6eefd2d9827466a696c44ced82dfbc18"},
+    {file = "numpy-2.3.5-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:2feae0d2c91d46e59fcd62784a3a83b3fb677fead592ce51b5a6fbb4f95965ff"},
+    {file = "numpy-2.3.5-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffac52f28a7849ad7576293c0cb7b9f08304e8f7d738a8cb8a90ec4c55a998eb"},
+    {file = "numpy-2.3.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63c0e9e7eea69588479ebf4a8a270d5ac22763cc5854e9a7eae952a3908103f7"},
+    {file = "numpy-2.3.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f16417ec91f12f814b10bafe79ef77e70113a2f5f7018640e7425ff979253425"},
+    {file = "numpy-2.3.5.tar.gz", hash = "sha256:784db1dcdab56bf0517743e746dfb0f885fc68d948aba86eeec2cba234bdf1c0"},
 ]
 
 [[package]]
@@ -4638,4 +4724,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "2acf8b990591bfbc7e35db5bb4ff4dd58b783c41d5749646693a145dfdb0147d"
+content-hash = "c01e7c005751c46c2bed4fe392dc33c9eb9ca4d06e1b9a1812cfe07f075bd2d8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3957,14 +3957,14 @@ files = [
 
 [[package]]
 name = "spextra"
-version = "0.43.0"
+version = "0.43.1"
 description = "Tool to manage and manipulate astronomical spectra."
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["main"]
 files = [
-    {file = "spextra-0.43.0-py3-none-any.whl", hash = "sha256:84d6ecddc4d6f4e325c062e608442c633f51343c0a47d90a63d9acf272c08f70"},
-    {file = "spextra-0.43.0.tar.gz", hash = "sha256:5e4c2e07db82448750c635f1fd46c83308389881e5712aeca157edb0d74f6c9a"},
+    {file = "spextra-0.43.1-py3-none-any.whl", hash = "sha256:27f708ac5fe96e9a6fd38ee006780a951afb7e3fad773f36c6f55cc14b54a1e2"},
+    {file = "spextra-0.43.1.tar.gz", hash = "sha256:ab53600902f37c85231be5013f1a5e4a44be2956e3142df6a977a4627414c349"},
 ]
 
 [package.dependencies]
@@ -3982,7 +3982,7 @@ scipy = [
     {version = ">=1.17.0,<1.18.0", markers = "python_version >= \"3.11\""},
 ]
 synphot = ">=1.6.1,<2.0.0"
-tqdm = ">=4.66.3,<5.0.0"
+tqdm = ">=4.67.1,<5.0.0"
 
 [[package]]
 name = "sphinx"
@@ -4638,4 +4638,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.15"
-content-hash = "5644366ef7a32e652c4be67133d9468f81c0e18a8d9092a32cbfa61fa046987d"
+content-hash = "2acf8b990591bfbc7e35db5bb4ff4dd58b783c41d5749646693a145dfdb0147d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = [ "classifiers" ]
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "numpy (>=1.26.4,<2.3.0) ; python_version >= '3.10' and python_version < '3.13'",
-    "numpy (>=2.2.6,<3.0.0) ; python_version >= '3.13'",
+    "numpy (>=2.3.5,<3.0.0) ; python_version >= '3.13'",
     # SciPy is only an indirect dependency through synphot, but has limited
     # wheels for Python versions, so needs to be specified explicitly.
     "scipy (>=1.15.3,<1.16.0) ; python_version >= '3.10' and python_version < '3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
     "scopesim (>=0.11.2,<0.12.0)",
     "pyckles (>=0.6.0,<1.0)",
-    "spextra (>=0.43.0,<1.0)",
+    "spextra (>=0.43.1,<1.0)",
     "astar-utils (>=0.5.0,<1.0)",
 ]
 

--- a/scopesim_templates/extragalactic/galaxies.py
+++ b/scopesim_templates/extragalactic/galaxies.py
@@ -14,8 +14,6 @@ from astropy.wcs import WCS
 from spextra import Spextrum
 
 from ..rc import Source, create_wcs_from_points
-from ..rc import ter_curve_utils as tcu
-
 from ..extragalactic import galaxy_utils as gal_utils
 from ..extragalactic.exgal_models import GalaxyBase
 from ..misc.misc import source_from_array
@@ -432,7 +430,8 @@ def elliptical(r_eff, pixel_scale, filter_name, amplitude,
     if params["rescale_spectrum"]:
         if not isinstance(amplitude, u.Quantity):
             amplitude <<= u.ABmag
-        spectrum = tcu.scale_spectrum(spectrum, filter_name, amplitude)
+        spectrum = Spextrum(modelclass=spectrum).scale_to_magnitude(
+            filter_curve=filter_name, amplitude=amplitude)
 
     # 4 make Source object
     src = Source(spectra=[spectrum], image_hdu=hdu)

--- a/scopesim_templates/micado/viking_fields/viking_fields.py
+++ b/scopesim_templates/micado/viking_fields/viking_fields.py
@@ -5,11 +5,10 @@ from astropy.io import ascii
 from astropy import units as u
 import yaml
 
-import pyckles
+from spextra import Spextrum
 
 from ...stellar import stars
 from ...extragalactic import elliptical
-from ...rc import ter_curve_utils as tcu
 from ...rc import Source
 
 
@@ -188,9 +187,8 @@ def load_galaxies_source(cat_id="1", pixel_scale=0.004, xs=None, ys=None,
     if ys is None:
         ys = np.random.random(n_gals) * box_size - 0.5 * box_size   # [arcsec]
 
-    brown_lib = pyckles.SpectralLibrary("brown", return_style="synphot")
-    spectrum = brown_lib["NGC_0584"]
-    spectrum = tcu.scale_spectrum(spectrum, filter_name="H", amplitude=0*u.mag)
+    spectrum = Spextrum("brown/NGC0584").scale_to_magnitude(
+        filter_curve="H", amplitude=0*u.mag)
 
     srcs = []
     for i in range(n_gals):

--- a/scopesim_templates/misc/misc.py
+++ b/scopesim_templates/misc/misc.py
@@ -14,10 +14,11 @@ from astropy.utils.decorators import deprecated_renamed_argument
 
 from synphot import SourceSpectrum, Empirical1D
 
-from spextra import Spextrum
-from ..rc import Source, ter_curve_utils as tu
-from ..utils.general_utils import add_function_call_str, make_img_wcs_header,\
-    RA0, DEC0
+from spextra import Spextrum, Passband
+
+from ..rc import Source
+from ..utils.general_utils import (add_function_call_str, make_img_wcs_header,
+                                   RA0, DEC0)
 
 
 __all__ = ["point_source",
@@ -205,13 +206,13 @@ def source_from_imagehdu(image_hdu, filter_name, pixel_unit_amplitude=None,
     amp_unit = amp * u.Unit(units)
 
     if filter_name is not None and isinstance(filter_name, str):
-        filter_curve = tu.get_filter(filter_name)
-        waverange = filter_curve.waverange
+        waverange = Passband(filter_name).waverange
 
     waves = np.linspace(waverange[0], waverange[1], num=10)
     lookup_table = [1,] * len(waves)
     spec = SourceSpectrum(Empirical1D, points=waves, lookup_table=lookup_table)
-    spec = tu.scale_spectrum(spec, filter_name=filter_name, amplitude=amp_unit)
+    spec = Spextrum(modelclass=spec).scale_to_magnitude(
+        filter_curve=filter_name, amplitude=amp_unit)
 
     if image_hdu.header.get("SPEC_REF") is None:
         image_hdu.header["SPEC_REF"] = 0

--- a/scopesim_templates/misc/misc.py
+++ b/scopesim_templates/misc/misc.py
@@ -15,6 +15,7 @@ from astropy.utils.decorators import deprecated_renamed_argument
 from synphot import SourceSpectrum, Empirical1D
 
 from spextra import Spextrum, Passband
+from spextra.exceptions import ConstructorError
 
 from ..rc import Source
 from ..utils.general_utils import (add_function_call_str, make_img_wcs_header,
@@ -206,7 +207,11 @@ def source_from_imagehdu(image_hdu, filter_name, pixel_unit_amplitude=None,
     amp_unit = amp * u.Unit(units)
 
     if filter_name is not None and isinstance(filter_name, str):
-        waverange = Passband(filter_name).waverange
+        try:
+            passband = Passband(filter_name)
+        except ConstructorError:  # might be local file name
+            passband = Passband.from_file(filter_name)
+        waverange = passband.waverange
 
     waves = np.linspace(waverange[0], waverange[1], num=10)
     lookup_table = [1,] * len(waves)

--- a/scopesim_templates/rc.py
+++ b/scopesim_templates/rc.py
@@ -6,7 +6,6 @@ from astar_utils import NestedMapping
 import scopesim
 
 Source = scopesim.source.source.Source
-ter_curve_utils = scopesim.effects.ter_curves_utils
 
 create_wcs_from_points = scopesim.optics.image_plane_utils.create_wcs_from_points
 load_example_optical_train = scopesim.load_example_optical_train

--- a/scopesim_templates/stellar/clusters.py
+++ b/scopesim_templates/stellar/clusters.py
@@ -94,7 +94,6 @@ def cluster(mass=1E3, distance=50000, core_radius=1, ra=RA0, dec=DEC0,
     spectra = [pickles[spt] for spt in unique_spts]
 
     # 4. scale all spectra to V=0
-    # spectra = [tcu.scale_spectrum(spec, "V", 0*u.mag) for spec in spectra]
     spectra = [Spextrum(modelclass=spec).scale_to_magnitude(filter_curve="V",
                                                             amplitude=0*u.mag)
                for spec in spectra]

--- a/scopesim_templates/stellar/stellar.py
+++ b/scopesim_templates/stellar/stellar.py
@@ -236,8 +236,6 @@ def stars(filter_name, amplitudes, spec_types, x, y, library="pyckles",
         weight = amplitudes.value
 
     if library == "pyckles":
-        # spectra = [tcu.scale_spectrum(pickles_lib[spt], filter_name, zero)
-        #            for spt in zip(cat_spec_types)]
         spectra = [Spextrum(modelclass=pickles_lib[spt]).scale_to_magnitude(
             filter_curve=filter_name, amplitude=zero)
                    for spt in cat_spec_types]

--- a/scopesim_templates/tests/test_stellar/test_stars.py
+++ b/scopesim_templates/tests/test_stellar/test_stars.py
@@ -42,7 +42,7 @@ class TestStars:
         ("filter_src", "filter_obs", "unit", "expected"),
         [("Generic/Johnson.V", "Generic/Johnson.J", sp.units.PHOTLAM, 193),
          ("Generic/Johnson.V", "Generic/Johnson.I", u.Jansky, 2367),
-         ("Paranal/HAWKI.J", "Paranal/HAWKI.J", sp.units.PHOTLAM, 187)]
+         ("Paranal/HAWKI.J", "Paranal/HAWKI.J", sp.units.PHOTLAM, 185)]
     )
     def test_returns_correct_photon_counts_when_scaled_to_vega_zero(
             self, filter_src, filter_obs, unit, expected):


### PR DESCRIPTION
Like #163, this was pulled from and older branch and rebased. This is the final episode in that series.

There was already a mix of both way of scaling spectra in here, so nothing completely new. One less circular import...

In test_stellar/test_stars I also refactored the test cases a little.